### PR TITLE
Limit TF version by <2.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     "regex",
     "requests",
     "scikit-learn",
-    "tensorflow>=2.3.0"
+    "tensorflow>=2.3.0, <2.6.0"
 ]
 
 setuptools.setup(


### PR DESCRIPTION
Limit TF version by <2.6.0
TF 2.6.x contain a newly released bug that will crush program on importing `keras.models`
https://forums.developer.nvidia.com/t/unable-to-import-keras-models-on-tensorflow-2-6-0-jetpack-v46/191904

Code:
`from tensorflow.keras.models import load_model`

Error:
```
credsweeper/ml_model/ml_validator.py:9: in <module>
    from tensorflow.keras.models import load_model
...
tensorflow.python.framework.errors_impl.AlreadyExistsError: Another metric with the same name already exists.
```
