### PR TITLE
Add Firebase rule

### DIFF
--- a/credsweeper/rules/config.yaml
+++ b/credsweeper/rules/config.yaml
@@ -358,3 +358,12 @@
   use_ml: false
   validations:
   - GithubTokenValidation
+
+- name: Firebase Domain
+  severity: high
+  type: pattern
+  values:
+   - (?P<value>[a-z0-9.-]+\.firebaseio\.com|[a-z0-9.-]+\.firebaseapp\.com)
+  filter_type: GeneralPattern
+  use_ml: false
+  validations: []

--- a/tests/rules/test_firebase_domain.py
+++ b/tests/rules/test_firebase_domain.py
@@ -1,0 +1,17 @@
+from typing import List
+
+import pytest
+
+from .common import BaseTestRule
+
+
+class TestFirebasDomain(BaseTestRule):
+    @pytest.fixture(params=[
+        ["api-project-615509201590.firebaseio.com"],
+        ["api-project-615509201590.firebaseapp.com"]])
+    def lines(self, request) -> List[str]:
+        return request.param
+
+    @pytest.fixture
+    def rule_name(self) -> str:
+        return "Firebase Domain"


### PR DESCRIPTION
Hello,

Added Firebase detection rules.

```
hack@hack:~$ cat strings.txt 
    <string name="firebase_database_url">https://api-project-615509201123.firebaseio.com</string>
    <string name="firebase_database_url">https://api-project-615509201123.firebaseapp.com</string>
```

```
hack@hack:~$ python3 -m credsweeper --path /home/hack/strings.txt --rule /home/hack/config.yaml 
rule: Firebase io Token / severity: high / line_data_list: [line : '    <string name="firebase_database_url">https://api-project-615509201123.firebaseio.com</string>' / line_num : 1 / path : /home/hack/strings.txt / value: 'api-project-615509201123.firebaseio.com' / entropy_validation: True] / api_validation: NOT_AVAILABLE / ml_validation: NOT_AVAILABLE
rule: Firebase APP Token / severity: high / line_data_list: [line : '    <string name="firebase_database_url">https://api-project-615509201123.firebaseapp.com</string>' / line_num : 2 / path : /home/hack/strings.txt / value: 'api-project-615509201123.firebaseapp.com' / entropy_validation: True] / api_validation: NOT_AVAILABLE / ml_validation: NOT_AVAILABLE
```

Thanks.

Ref: https://hackerone.com/reports/1065134