### PR TITLE
List owners by account in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Samsung/CredSweeper_Maintainers
+* @silentearth @csh519 @yuzzyuzz @meanrin @Dmitriy-NK @ARKAD97


### PR DESCRIPTION
Current opting with using group name as code owners is nice and compact
Unfortunately it do not list group users in "Reviewers" so even if you notified: you still need to request this review on yourself, before you can lest a review 

![image](https://user-images.githubusercontent.com/43581724/141825518-09b4665f-16e5-4fb5-8386-53c697f266f1.png)


This PR change this back

It's optional quality of life improvement 