### PR TITLE
Add tensorflow 2.7.0, 2.6.2 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
 ml_requires = [
     "numpy",
     "scikit-learn",
-    "tensorflow>=2.3.0, <2.6.0"
+    "tensorflow>=2.3.0, !=2.6.0, !=2.6.1"
 ]
 
 setuptools.setup(


### PR DESCRIPTION
Allow tensorflow `2.6.2` and `2.7.0` instalstion
Both released 13 days ago: https://github.com/tensorflow/tensorflow/releases

TF `2.6.1` and `2.6.0` still have a bug that brakes `load_model` function