### PR TITLE
Quick Fix duplicated report note for each element in multiline rule

### DIFF
--- a/credsweeper/credentials/credential_manager.py
+++ b/credsweeper/credentials/credential_manager.py
@@ -55,7 +55,7 @@ class CredentialManager:
         """
         groups = CandidateGroupGenerator()
         for credential_candidate in self.get_credentials():
-            for line_data in credential_candidate.line_data_list:
+            for line_data in credential_candidate.line_data_list[:1]:
                 # Match by file path+line num+value. Value required so two different credentials still be
                 #  processed independently
                 candidate_key = CandidateKey(line_data)


### PR DESCRIPTION
Using ML validation for multiline rules leads to duplicate report note for each line data in line_data_list, as below: 

> rule: AWS Client ID / severity: high / line_data_list: [line: ' clid = "AKIAQWADE5R42RDZ4JEM"' / line_num: 4 / path: creds.py / value: 'AKIAQWADE5R42RDZ4JEM' / entropy_validation: False] / api_validation: NOT_AVAILABLE / ml_validation: VALIDATED_KEY
> **rule: AWS Multi / severity: high / line_data_list: [line: ' clid = "AKIAQWADE5R42RDZ4JEM"' / line_num: 4 / path: creds.py / value: 'AKIAQWADE5R42RDZ4JEM' / entropy_validation: False, line: ' token = "V84C7sDU001tFFodKU95USNy97TkqXymnvsFmYhQ"' / line_num: 5 / path: creds.py / value: 'V84C7sDU001tFFodKU95USNy97TkqXymnvsFmYhQ' / entropy_validation: True] / api_validation: NOT_AVAILABLE / ml_validation: VALIDATED_KEY
> rule: AWS Multi / severity: high / line_data_list: [line: ' clid = "AKIAQWADE5R42RDZ4JEM"' / line_num: 4 / path: creds.py / value: 'AKIAQWADE5R42RDZ4JEM' / entropy_validation: False, line: ' token = "V84C7sDU001tFFodKU95USNy97TkqXymnvsFmYhQ"' / line_num: 5 / path: creds.py / value: 'V84C7sDU001tFFodKU95USNy97TkqXymnvsFmYhQ' / entropy_validation: True] / api_validation: NOT_AVAILABLE / ml_validation: VALIDATED_KEY**
> rule: Token / severity: medium / line_data_list: [line: ' token = "V84C7sDU001tFFodKU95USNy97TkqXymnvsFmYhQ"' / line_num: 5 / path: creds.py / value: 'V84C7sDU001tFFodKU95USNy97TkqXymnvsFmYhQ' / entropy_validation: True] / api_validation: NOT_AVAILABLE / ml_validation: VALIDATED_KEY

Till there is no complete management solution for such cases, it's proposed to leave one option with a solution of ML_validation for the main line.