### PR TITLE
Update patch anlisys for support multiline rules

### DIFF
--- a/credsweeper/common/constants.py
+++ b/credsweeper/common/constants.py
@@ -57,3 +57,10 @@ class RuleType(Enum):
 class ThresholdPreset(Enum):
     """Preset threshold to simplify precision/recall selection for the user"""
     balanced = "balanced"
+
+
+class DiffRowType:
+    ADDED = "added"
+    DELETED = "deleted"
+    ADDED_ACCOMPANY = "added_accompany"
+    DELETED_ACCOMPANY = "deleted_accompany"

--- a/credsweeper/file_handler/analysis_target.py
+++ b/credsweeper/file_handler/analysis_target.py
@@ -1,9 +1,10 @@
+
+from dataclasses import dataclass
 from typing import List
 
-
+@dataclass
 class AnalysisTarget:
-    def __init__(self, line: str, line_num: int, lines: List[str], file_path: str):
-        self.line = line
-        self.line_num = line_num
-        self.lines = lines
-        self.file_path = file_path
+    line: str
+    line_num: int
+    lines: List[str]
+    file_path: str

--- a/credsweeper/file_handler/diff_content_provider.py
+++ b/credsweeper/file_handler/diff_content_provider.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from credsweeper.file_handler.analysis_target import AnalysisTarget
 from credsweeper.file_handler.content_provider import ContentProvider
@@ -28,11 +28,23 @@ class DiffContentProvider(ContentProvider):
         self.diff = diff
         self.file_path = file_path
 
+    def parse_lines_data(self, lines_data: List[Tuple[str, int, str]]) -> Tuple[List[int], List[str]]:
+        max_line_numbs = max(x[1] for x in lines_data)
+        all_lines = ["" for _ in range(max_line_numbs)]
+        change_numbs = []
+        for line_type, line_numb, line in lines_data:
+            if line_type.startswith(self.change_type):
+                all_lines[line_numb - 1] = line
+            if line_type == self.change_type:
+                change_numbs.append(line_numb)
+        return change_numbs, all_lines
+
     def get_analysis_target(self) -> List[AnalysisTarget]:
         """Preprocess file diff data to scan
 
         Return:
             list of analysis targets of every row of file diff corresponding to change type "self.change_type"
         """
-        line_numbs, lines = Util.preprocess_file_diff(self.diff, self.change_type)
-        return [AnalysisTarget(line, line_numb, lines, self.file_path) for line_numb, line in zip(line_numbs, lines)]
+        lines_data = Util.preprocess_file_diff(self.diff)
+        change_numbs, all_lines = self.parse_lines_data(lines_data)
+        return [AnalysisTarget(all_lines[l_numb - 1], l_numb, all_lines, self.file_path) for l_numb in change_numbs]

--- a/credsweeper/file_handler/diff_content_provider.py
+++ b/credsweeper/file_handler/diff_content_provider.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Tuple
 
 from credsweeper.file_handler.analysis_target import AnalysisTarget
 from credsweeper.file_handler.content_provider import ContentProvider
-from credsweeper.utils import Util
+from credsweeper.utils import DiffRowData, Util
 
 
 class DiffContentProvider(ContentProvider):
@@ -28,15 +28,27 @@ class DiffContentProvider(ContentProvider):
         self.diff = diff
         self.file_path = file_path
 
-    def parse_lines_data(self, lines_data: List[Tuple[str, int, str]]) -> Tuple[List[int], List[str]]:
-        max_line_numbs = max(x[1] for x in lines_data)
-        all_lines = ["" for _ in range(max_line_numbs)]
+    def parse_lines_data(self, lines_data: List[DiffRowData]) -> Tuple[List[int], List[str]]:
+        """Parse diff lines data
+
+        Return list of line numbers with change type "self.change_type" and list of all lines in file
+            in original order(replaced all lines not mentioned in diff file with blank line)
+
+        Args:
+            lines_data: list of DiffRowData object, data of all rows mentioned in diff file
+
+        Return:
+            change_numbs: list of integer, line numbers with change type "self.change_type"
+            all_lines: all file lines in original order(replaced all lines not mentioned in diff file with blank line)
+        """
+        max_line_numbs = max(x.line_numb for x in lines_data)
+        all_lines = [""] * max_line_numbs
         change_numbs = []
-        for line_type, line_numb, line in lines_data:
-            if line_type.startswith(self.change_type):
-                all_lines[line_numb - 1] = line
-            if line_type == self.change_type:
-                change_numbs.append(line_numb)
+        for line_data in lines_data:
+            if line_data.line_type.startswith(self.change_type):
+                all_lines[line_data.line_numb - 1] = line_data.line
+            if line_data.line_type == self.change_type:
+                change_numbs.append(line_data.line_numb)
         return change_numbs, all_lines
 
     def get_analysis_target(self) -> List[AnalysisTarget]:

--- a/credsweeper/utils/__init__.py
+++ b/credsweeper/utils/__init__.py
@@ -1,1 +1,1 @@
-from credsweeper.utils.util import Util
+from credsweeper.utils.util import DiffRowData, Util

--- a/credsweeper/utils/util.py
+++ b/credsweeper/utils/util.py
@@ -109,7 +109,7 @@ class Util:
         return {}
 
     @classmethod
-    def preprocess_file_diff(cls, changes: List[Dict], change_type: str) -> Tuple[List[int], List[str]]:
+    def preprocess_file_diff(cls, changes: List[Dict]) -> List[Tuple[str, int, str]]:
         """Generates files rows from diff with only added and deleted lines (e.g. marked + or - in diff)
 
         Args:
@@ -118,26 +118,20 @@ class Util:
         Return:
             Tuple of to lists: list of line numbers and list of line texts
         """
-        add_rows, del_rows = [], []
-        add_numbs, del_numbs = [], []
+        rows_data = []
         if changes is None:
-            return [], []
+            return []
 
-        # process diff to restore only added and deleted lines and their positions
+        # process diff to restore lines and their positions
         for change in changes:
             if change.get("old") is None:
                 # indicates line was inserted
-                add_rows.append(change.get("line"))
-                add_numbs.append(change.get("new"))
+                rows_data.append(["added", change.get("new"), change.get("line")])
             elif change.get("new") is None:
                 # indicates line was removed
-                del_rows.append(change.get("line"))
-                del_numbs.append(change.get("old"))
+                rows_data.append(["deleted", change.get("old"), change.get("line")])
+            else:
+                rows_data.append(["added_accompany", change.get("new"), change.get("line")])
+                rows_data.append(["deleted_accompany", change.get("old"), change.get("line")])
 
-        if change_type == "added":
-            return add_numbs, add_rows
-        elif change_type == "deleted":
-            return del_numbs, del_rows
-        else:
-            logging.error(f"Change type should be one of: 'added', 'deleted'; but recieved {change_type}")
-        return [], []
+        return rows_data

--- a/credsweeper/utils/util.py
+++ b/credsweeper/utils/util.py
@@ -2,7 +2,7 @@ import logging
 import math
 import os
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
 from regex import regex
 import whatthepatch
@@ -16,14 +16,6 @@ class DiffRowData:
     line_type: str
     line_numb: int
     line: str
-
-    def get_data(self) -> float:
-        return self.unit_price * self.quantity_on_hand
-
-    # def __init__(self, line_type: str, line_numb: int, line: str):
-    #     self.line_type = line_type
-    #     self.line_numb = line_numb
-    #     self.line = line
 
 
 class Util:

--- a/credsweeper/utils/util.py
+++ b/credsweeper/utils/util.py
@@ -1,12 +1,29 @@
 import logging
 import math
 import os
+from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
 from regex import regex
 import whatthepatch
 
-from credsweeper.common.constants import Chars, KeywordPattern, Separator
+from credsweeper.common.constants import Chars, DiffRowType, KeywordPattern, Separator
+
+
+@dataclass
+class DiffRowData:
+    """Class for keeping data of diff row."""
+    line_type: str
+    line_numb: int
+    line: str
+
+    def get_data(self) -> float:
+        return self.unit_price * self.quantity_on_hand
+
+    # def __init__(self, line_type: str, line_numb: int, line: str):
+    #     self.line_type = line_type
+    #     self.line_numb = line_numb
+    #     self.line = line
 
 
 class Util:
@@ -109,7 +126,7 @@ class Util:
         return {}
 
     @classmethod
-    def preprocess_file_diff(cls, changes: List[Dict]) -> List[Tuple[str, int, str]]:
+    def preprocess_file_diff(cls, changes: List[Dict]) -> List[DiffRowData]:
         """Generates files rows from diff with only added and deleted lines (e.g. marked + or - in diff)
 
         Args:
@@ -126,12 +143,12 @@ class Util:
         for change in changes:
             if change.get("old") is None:
                 # indicates line was inserted
-                rows_data.append(["added", change.get("new"), change.get("line")])
+                rows_data.append(DiffRowData(DiffRowType.ADDED, change.get("new"), change.get("line")))
             elif change.get("new") is None:
                 # indicates line was removed
-                rows_data.append(["deleted", change.get("old"), change.get("line")])
+                rows_data.append(DiffRowData(DiffRowType.DELETED, change.get("old"), change.get("line")))
             else:
-                rows_data.append(["added_accompany", change.get("new"), change.get("line")])
-                rows_data.append(["deleted_accompany", change.get("old"), change.get("line")])
+                rows_data.append(DiffRowData(DiffRowType.ADDED_ACCOMPANY, change.get("new"), change.get("line")))
+                rows_data.append(DiffRowData(DiffRowType.DELETED_ACCOMPANY, change.get("old"), change.get("line")))
 
         return rows_data

--- a/tests/file_handler/test_diff_content_provider.py
+++ b/tests/file_handler/test_diff_content_provider.py
@@ -1,0 +1,114 @@
+from credsweeper.common.constants import DiffRowType
+from credsweeper.file_handler.diff_content_provider import DiffContentProvider
+from credsweeper.utils import DiffRowData
+
+class TestDiffContentProvider:
+    def test_get_analysis_target_p(self) -> None:
+        """Evaluate that added diff lines data correctly added to change_numbers"""
+        file_path = "dumy.file"
+        diff = [
+            {
+                "old": None,
+                "new": 2,
+                "line": "new line",
+                "hunk": 1
+            },
+            {
+                "old": 2,
+                "new": 3,
+                "line": "moved line",
+                "hunk": 1
+            }
+        ]
+        content_provider = DiffContentProvider(file_path, "added", diff)
+
+        analysis_targets = content_provider.get_analysis_target()
+
+        all_lines = ["", "new line", "moved line"]
+
+        assert len(analysis_targets) == 1
+
+        target = analysis_targets[0]
+        assert target.line == "new line"
+        assert target.line_num == 2
+        assert target.lines == all_lines
+        assert target.file_path == file_path
+
+    def test_get_analysis_target_n(self) -> None:
+        """Evaluate that deleted diff lines data correctly filtered for added change type"""
+        file_path = "dumy.file"
+        diff = [
+            {
+                "old": 2,
+                "new": None,
+                "line": "new line",
+                "hunk": 1
+            },
+            {
+                "old": 3,
+                "new": 2,
+                "line": "moved line",
+                "hunk": 1
+            }
+        ]
+        content_provider = DiffContentProvider(file_path, "added", diff)
+
+        analysis_targets = content_provider.get_analysis_target()
+
+        assert len(analysis_targets) == 0
+
+    def test_parse_lines_data_p(self) -> None:
+        """Evaluate that added diff lines data correctly added to change_numbers"""
+        file_path = "dumy.file"
+        diff = []
+        content_provider = DiffContentProvider(file_path, "added", diff)
+
+        lines_data = [DiffRowData(DiffRowType.ADDED, 2, "new line")]
+
+        change_numbs, _all_lines = content_provider.parse_lines_data(lines_data)
+
+        expected_numbs = [2]
+
+        assert change_numbs == expected_numbs
+
+    def test_parse_lines_data_n(self) -> None:
+        """Evaluate that deleted diff lines data correctly filtered for added change type"""
+        file_path = "dumy.file"
+        diff = []
+        content_provider = DiffContentProvider(file_path, "added", diff)
+
+        lines_data = [DiffRowData(DiffRowType.DELETED, 2, "old line")]
+
+        change_numbs, _all_lines = content_provider.parse_lines_data(lines_data)
+
+        expected_numbs = []
+
+        assert change_numbs == expected_numbs
+
+    def test_accompany_parse_lines_data_p(self) -> None:
+        """Evaluate that added diff lines data correctly added to all_lines"""
+        file_path = "dumy.file"
+        diff = []
+        content_provider = DiffContentProvider(file_path, "added", diff)
+
+        lines_data = [DiffRowData(DiffRowType.ADDED_ACCOMPANY, 2, "new line")]
+
+        _change_numbs, all_lines = content_provider.parse_lines_data(lines_data)
+
+        expected_lines = ["", "new line"]
+
+        assert all_lines == expected_lines
+
+    def test_accompany_parse_lines_data_n(self) -> None:
+        """Evaluate that deleted diff lines data correctly filtered for added change type"""
+        file_path = "dumy.file"
+        diff = []
+        content_provider = DiffContentProvider(file_path, "added", diff)
+
+        lines_data = [DiffRowData(DiffRowType.ADDED_ACCOMPANY, 2, "new ine")]
+
+        change_numbs, _all_lines = content_provider.parse_lines_data(lines_data)
+
+        expected_numbs = []
+
+        assert change_numbs == expected_numbs

--- a/tests/file_handler/test_diff_content_provider.py
+++ b/tests/file_handler/test_diff_content_provider.py
@@ -1,4 +1,5 @@
 from credsweeper.common.constants import DiffRowType
+from credsweeper.file_handler.analysis_target import AnalysisTarget
 from credsweeper.file_handler.diff_content_provider import DiffContentProvider
 from credsweeper.utils import DiffRowData
 
@@ -25,14 +26,12 @@ class TestDiffContentProvider:
         analysis_targets = content_provider.get_analysis_target()
 
         all_lines = ["", "new line", "moved line"]
+        expected_target = AnalysisTarget("new line", 2, all_lines, file_path)
 
         assert len(analysis_targets) == 1
 
         target = analysis_targets[0]
-        assert target.line == "new line"
-        assert target.line_num == 2
-        assert target.lines == all_lines
-        assert target.file_path == file_path
+        assert target == expected_target
 
     def test_get_analysis_target_n(self) -> None:
         """Evaluate that deleted diff lines data correctly filtered for added change type"""

--- a/tests/file_handler/test_text_content_provider.py
+++ b/tests/file_handler/test_text_content_provider.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from credsweeper.file_handler.text_content_provider import TextContentProvider
+
+class TestTextContentProvider:
+    def test_get_analysis_target_p(self) -> None:
+        """Evaluate that lines data correctly extracted from file"""
+        file_path = Path(__file__).resolve().parent.parent
+        target_path = file_path/"samples"/"password"
+        content_provider = TextContentProvider(target_path)
+
+        analysis_targets = content_provider.get_analysis_target()
+
+        all_lines = ['password = "cackle!"', '']
+
+        assert len(analysis_targets) == 2
+
+        target = analysis_targets[0]
+        assert target.line == 'password = "cackle!"'
+        assert target.line_num == 1
+        assert target.lines == all_lines
+        assert target.file_path == target_path

--- a/tests/file_handler/test_text_content_provider.py
+++ b/tests/file_handler/test_text_content_provider.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from credsweeper.file_handler.analysis_target import AnalysisTarget
 from credsweeper.file_handler.text_content_provider import TextContentProvider
 
 class TestTextContentProvider:
@@ -12,11 +13,9 @@ class TestTextContentProvider:
         analysis_targets = content_provider.get_analysis_target()
 
         all_lines = ['password = "cackle!"', '']
+        expected_target = AnalysisTarget('password = "cackle!"', 1, all_lines, target_path)
 
         assert len(analysis_targets) == 2
 
         target = analysis_targets[0]
-        assert target.line == 'password = "cackle!"'
-        assert target.line_num == 1
-        assert target.lines == all_lines
-        assert target.file_path == target_path
+        assert target == expected_target

--- a/tests/samples/multiline.patch
+++ b/tests/samples/multiline.patch
@@ -1,0 +1,12 @@
+diff --git a/creds.py b/creds.py
+index 7a91586..abe9b1d 100644
+--- a/creds.py
++++ b/creds.py
+@@ -3,7 +3,7 @@
++
+
++  clid = "AKIAQWADE5R42RDZ4JEM"
++  token = "V84C7sDU001tFFodKU95USNy97TkqXymnvsFmYhQ"
+
+
+


### PR DESCRIPTION
Update patch anlisys for support multiline rules. 
Previously row indexes for second line in multiline rule was incorrect.
 
Also, added test case for multiline rules handling and content providers