### PR TITLE
Update pypi regex

### DIFF
--- a/credsweeper/rules/config.yaml
+++ b/credsweeper/rules/config.yaml
@@ -335,7 +335,7 @@
   severity: high
   type: pattern
   values:
-   - (?P<value>pypi-AgEIcHlwaS5vcmc[\w_\-]{152})
+   - (?P<value>pypi-[\w_\-]{167})
   filter_type: GeneralPattern
   use_ml: false
   validations: []

--- a/credsweeper/rules/config.yaml
+++ b/credsweeper/rules/config.yaml
@@ -335,7 +335,7 @@
   severity: high
   type: pattern
   values:
-   - (?P<value>pypi-[\w_\-]{167})
+   - (?P<value>pypi-[\w_\-]{150,})
   filter_type: GeneralPattern
   use_ml: false
   validations: []

--- a/tests/rules/test_pypi_api_token.py
+++ b/tests/rules/test_pypi_api_token.py
@@ -11,7 +11,7 @@ class TestPyPiApiToken(BaseTestRule):
         "CJGE3ZjdlNzVmLTRhOGEtNGY1MC1iMzEwLWQzZTQ1NmJiYzMzMQ"
         "ACJXsicGVybWlzc2lvbnMiOiAidXNlciIsICJ2ZXJzaW9uIjogM"
         "X0AAAYgdUBLuCnfvl7n3ZIgLjCvIDuk9GQxDbw4PHxRUAwPvIk"],
-        ["pypi-AgEIcHlwaS5vcmc"
+        ["pypi-AgENdGVzdC5weXB"
         "CJDc5ZThjYzc4LWViY2YtNGFiZS1iOTNiLTQ3ZWVjOGFmYjIxNQ"
         "ACJXsicGVybWlzc2lvbnMiOiAidXNlciIsICJ2ZXJzaW9uIjogM"
         "X0AAAYgNJxF-my_lC6DUayAYu3KhiASbVvQA8FLI7wo-OkXoLs"]])


### PR DESCRIPTION
Related to https://github.com/Samsung/CredSweeper/issues/26

Update pypi regex, as current regex cannot detect some real tokens

- Old regex included `AgEIcHlwaS5vcmc` at the start, which is not always the case for real tokens
- Real tokens can have different lengths