### PR TITLE
Update yapf config, rerun yapf/isort

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -57,7 +57,7 @@ blank_line_before_module_docstring=False
 #                      # <------ this blank line
 #     def method():
 #       ...
-blank_line_before_nested_class_or_def=False
+blank_line_before_nested_class_or_def=True
 
 # Do not split consecutive brackets. Only relevant when
 # dedent_closing_brackets is set. For example:

--- a/credsweeper/__main__.py
+++ b/credsweeper/__main__.py
@@ -3,9 +3,9 @@ from argparse import ArgumentParser, ArgumentTypeError
 from typing import Any
 
 from credsweeper.app import CredSweeper
-from credsweeper.logger.logger import logging, Logger
 from credsweeper.file_handler.patch_provider import PatchProvider
 from credsweeper.file_handler.text_provider import TextProvider
+from credsweeper.logger.logger import Logger, logging
 
 
 def positive_int(value: Any) -> int:

--- a/credsweeper/app.py
+++ b/credsweeper/app.py
@@ -9,9 +9,9 @@ from typing import Dict, List, Optional
 from credsweeper.common.constants import KeyValidationOption
 from credsweeper.config import Config
 from credsweeper.credentials import Candidate, CredentialManager
+from credsweeper.file_handler.content_provider import ContentProvider
 from credsweeper.logger.logger import logging
 from credsweeper.scanner import Scanner
-from credsweeper.file_handler.content_provider import ContentProvider
 from credsweeper.validations.apply_validation import ApplyValidation
 
 

--- a/credsweeper/config/config_manager.py
+++ b/credsweeper/config/config_manager.py
@@ -3,11 +3,11 @@ from pathlib import Path
 
 import yaml
 
-
 CONFIG_PATH = Path(__file__).resolve().parent.parent.joinpath('secret')
 
 
 class ConfigManager:
+
     @staticmethod
     def load_conf(conf_file):
         file_path = CONFIG_PATH.joinpath(conf_file)

--- a/credsweeper/credentials/candidate.py
+++ b/credsweeper/credentials/candidate.py
@@ -8,6 +8,7 @@ from credsweeper.validations.validation import Validation
 
 
 class Candidate:
+
     def __init__(self,
                  line_data_list: List[LineData],
                  patterns: List[regex.Pattern],

--- a/credsweeper/credentials/candidate_group_generator.py
+++ b/credsweeper/credentials/candidate_group_generator.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Tuple
+from typing import Dict, List, Tuple
 
 from credsweeper.credentials.candidate import Candidate
 from credsweeper.credentials.candidate_key import CandidateKey

--- a/credsweeper/credentials/candidate_group_generator.py
+++ b/credsweeper/credentials/candidate_group_generator.py
@@ -5,6 +5,7 @@ from credsweeper.credentials.candidate_key import CandidateKey
 
 
 class CandidateGroupGenerator:
+
     def __init__(self) -> None:
         self.grouped_candidates: Dict[CandidateKey, List[Candidate]] = {}
 

--- a/credsweeper/file_handler/analysis_target.py
+++ b/credsweeper/file_handler/analysis_target.py
@@ -1,4 +1,3 @@
-
 from dataclasses import dataclass
 from typing import List
 

--- a/credsweeper/file_handler/content_provider.py
+++ b/credsweeper/file_handler/content_provider.py
@@ -8,10 +8,7 @@ class ContentProvider(ABC):
     """Base class to provide access to analysis targets for scanned object."""
 
     @abstractmethod
-    def __init__(self,
-                 file_path: str,
-                 change_type: Optional[str] = None,
-                 diff: Optional[List[Dict]] = None) -> None:
+    def __init__(self, file_path: str, change_type: Optional[str] = None, diff: Optional[List[Dict]] = None) -> None:
         raise NotImplementedError()
 
     def get_file_path(self) -> str:

--- a/credsweeper/file_handler/diff_content_provider.py
+++ b/credsweeper/file_handler/diff_content_provider.py
@@ -22,10 +22,7 @@ class DiffContentProvider(ContentProvider):
 
     """
 
-    def __init__(self,
-                 file_path: str,
-                 change_type: str,
-                 diff: List[Dict]) -> None:
+    def __init__(self, file_path: str, change_type: str, diff: List[Dict]) -> None:
         self.change_type = change_type
         self.diff = diff
         self.file_path = file_path

--- a/credsweeper/file_handler/patch_provider.py
+++ b/credsweeper/file_handler/patch_provider.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional
 
-from credsweeper.file_handler.files_provider import FilesProvider
 from credsweeper.file_handler.diff_content_provider import DiffContentProvider
+from credsweeper.file_handler.files_provider import FilesProvider
 from credsweeper.utils import Util
 
 

--- a/credsweeper/file_handler/text_content_provider.py
+++ b/credsweeper/file_handler/text_content_provider.py
@@ -14,10 +14,7 @@ class TextContentProvider(ContentProvider):
 
     """
 
-    def __init__(self,
-                 file_path: str,
-                 change_type: Optional[str] = None,
-                 diff: Optional[List[Dict]] = None) -> None:
+    def __init__(self, file_path: str, change_type: Optional[str] = None, diff: Optional[List[Dict]] = None) -> None:
         self.file_path = file_path
 
     def get_analysis_target(self) -> List[AnalysisTarget]:

--- a/credsweeper/file_handler/text_provider.py
+++ b/credsweeper/file_handler/text_provider.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional
 
-from credsweeper.file_handler.files_provider import FilesProvider
 from credsweeper.file_handler.file_path_extractor import FilePathExtractor
+from credsweeper.file_handler.files_provider import FilesProvider
 from credsweeper.file_handler.text_content_provider import TextContentProvider
 
 

--- a/credsweeper/filters/group/general_keyword.py
+++ b/credsweeper/filters/group/general_keyword.py
@@ -5,6 +5,7 @@ from credsweeper.filters.group import Group
 
 
 class GeneralKeyword(Group):
+
     def __init__(self, config: Config) -> None:
         super().__init__(config, GroupType.KEYWORD)
         self.filters.extend([ValueDictionaryKeywordCheck(), ValueUselessWordCheck()])

--- a/credsweeper/filters/group/general_pattern.py
+++ b/credsweeper/filters/group/general_pattern.py
@@ -4,5 +4,6 @@ from credsweeper.filters.group import Group
 
 
 class GeneralPattern(Group):
+
     def __init__(self, config: Config) -> None:
         super().__init__(config, GroupType.PATTERN)

--- a/credsweeper/filters/group/group.py
+++ b/credsweeper/filters/group/group.py
@@ -11,6 +11,7 @@ from credsweeper.filters import (Filter, LineSpecificKeyCheck, SeparatorUnusualC
 
 
 class Group(ABC):
+
     def __init__(self, config: Config, rule_type: GroupType) -> None:
         if rule_type == GroupType.KEYWORD:
             self.filters: List[Filter] = self.get_keyword_base_filters(config)

--- a/credsweeper/filters/group/password_keyword.py
+++ b/credsweeper/filters/group/password_keyword.py
@@ -5,6 +5,7 @@ from credsweeper.filters.group import Group
 
 
 class PasswordKeyword(Group):
+
     def __init__(self, config: Config) -> None:
         super().__init__(config, GroupType.KEYWORD)
         self.filters.extend([ValueDictionaryValueLengthCheck()])

--- a/credsweeper/filters/group/pem_pattern.py
+++ b/credsweeper/filters/group/pem_pattern.py
@@ -5,6 +5,7 @@ from credsweeper.filters.group import Group
 
 
 class PEMPattern(Group):
+
     def __init__(self, config: Config) -> None:
         super().__init__(config, GroupType.PATTERN)
         self.filters = [LineSpecificKeyCheck()]

--- a/credsweeper/filters/group/url_credentials_group.py
+++ b/credsweeper/filters/group/url_credentials_group.py
@@ -3,7 +3,7 @@ from credsweeper.config import Config
 from credsweeper.filters import (ValueAllowlistCheck, ValueArrayDictionaryCheck, ValueBlocklistCheck,
                                  ValueCamelCaseCheck, ValueDictionaryValueLengthCheck, ValueFilePathCheck,
                                  ValueFirstWordCheck, ValueLastWordCheck, ValueLengthCheck, ValueMethodCheck,
-                                 ValueNotAllowedPatternCheck, ValueStringTypeCheck, ValueTokenCheck, ValuePatternCheck)
+                                 ValueNotAllowedPatternCheck, ValuePatternCheck, ValueStringTypeCheck, ValueTokenCheck)
 from credsweeper.filters.group import Group
 
 

--- a/credsweeper/filters/group/url_credentials_group.py
+++ b/credsweeper/filters/group/url_credentials_group.py
@@ -8,6 +8,7 @@ from credsweeper.filters.group import Group
 
 
 class UrlCredentialsGroup(Group):
+
     def __init__(self, config: Config) -> None:
         """URL credentials group class.
 

--- a/credsweeper/filters/value_pattern_filter.py
+++ b/credsweeper/filters/value_pattern_filter.py
@@ -3,7 +3,6 @@ from regex import regex
 from credsweeper.credentials import LineData
 from credsweeper.filters import Filter
 
-
 DEFAULT_PATTERN_LEN = 4
 
 

--- a/credsweeper/logger/logger.py
+++ b/credsweeper/logger/logger.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from credsweeper.config import ConfigManager
 
-
 SILENCE = 60
 
 

--- a/credsweeper/ml_model/ml_validator.py
+++ b/credsweeper/ml_model/ml_validator.py
@@ -13,10 +13,8 @@ try:
     from tensorflow.python.keras.preprocessing.sequence import pad_sequences
     from tensorflow.python.keras.utils.np_utils import to_categorical
 except ModuleNotFoundError as e:
-    raise ModuleNotFoundError(
-        "The ML Validation function cannot be used without additional ML packages.\n"
-        "Run `pip install credsweeper[ml]` to fix it."
-    )
+    raise ModuleNotFoundError("The ML Validation function cannot be used without additional ML packages.\n"
+                              "Run `pip install credsweeper[ml]` to fix it.")
 
 from credsweeper.common.constants import ThresholdPreset
 from credsweeper.credentials import Candidate
@@ -26,6 +24,7 @@ from credsweeper.ml_model import features
 
 
 class MlValidator:
+
     @classmethod
     def __init__(cls, threshold_preset: ThresholdPreset = ThresholdPreset.balanced) -> None:
         tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)  # To make TF logger quiet

--- a/credsweeper/scanner/scan_type/multi_pattern.py
+++ b/credsweeper/scanner/scan_type/multi_pattern.py
@@ -62,8 +62,8 @@ class MultiPattern(ScanType):
         return candidate
 
     @classmethod
-    def scan(cls, config: Config, candidate: Candidate, line_num_margin: int, lines: List[str],
-             file_path: str, rule: Rule) -> bool:
+    def scan(cls, config: Config, candidate: Candidate, line_num_margin: int, lines: List[str], file_path: str,
+             rule: Rule) -> bool:
         """Search for second part of multiline rule near the current line.
 
         Automatically update candidate with detected line if any.

--- a/credsweeper/scanner/scan_type/scan_type.py
+++ b/credsweeper/scanner/scan_type/scan_type.py
@@ -62,7 +62,9 @@ class ScanType(ABC):
             return False
         for filter_ in filters:
             if filter_.run(line_data):
-                logging.debug(f"Filtered line with filter: {filter_.__class__.__name__} in file: {line_data.path}:{line_data.line_num} in line: {line_data.line}")
+                logging.debug(
+                    f"Filtered line with filter: {filter_.__class__.__name__} in file: {line_data.path}:{line_data.line_num} in line: {line_data.line}"
+                )
                 return True
         return False
 

--- a/credsweeper/scanner/scanner.py
+++ b/credsweeper/scanner/scanner.py
@@ -47,10 +47,7 @@ class Scanner:
         credentials = []
         for rule in self.rules:
             for target in targets:
-                new_credential = self.get_scanner(rule).run(self.config,
-                                                            target.line,
-                                                            target.line_num,
-                                                            target.file_path,
+                new_credential = self.get_scanner(rule).run(self.config, target.line, target.line_num, target.file_path,
                                                             rule, target.lines)
                 if new_credential:
                     logging.debug(

--- a/credsweeper/utils/util.py
+++ b/credsweeper/utils/util.py
@@ -4,8 +4,8 @@ import os
 from dataclasses import dataclass
 from typing import Dict, List
 
-from regex import regex
 import whatthepatch
+from regex import regex
 
 from credsweeper.common.constants import Chars, DiffRowType, KeywordPattern, Separator
 

--- a/credsweeper/utils/util.py
+++ b/credsweeper/utils/util.py
@@ -31,8 +31,8 @@ class Util:
 
     @classmethod
     def get_keyword_pattern(cls, keyword: str, separator: Separator = Separator.common) -> regex.Pattern:
-        return regex.compile(KeywordPattern.key.format(keyword) + KeywordPattern.separator.format(separator)
-                             + KeywordPattern.value,
+        return regex.compile(KeywordPattern.key.format(keyword) + KeywordPattern.separator.format(separator) +
+                             KeywordPattern.value,
                              flags=regex.IGNORECASE)
 
     @classmethod

--- a/credsweeper/validations/apply_validation.py
+++ b/credsweeper/validations/apply_validation.py
@@ -30,18 +30,22 @@ class ApplyValidation:
         validation_option = KeyValidationOption.UNDECIDED
 
         if not cred.is_api_validation_available:
-            logging.debug(f"No validation with external API available for current credential candidate: {cred.line_data_list[0].line}")
+            logging.debug(
+                f"No validation with external API available for current credential candidate: {cred.line_data_list[0].line}"
+            )
             return KeyValidationOption.NOT_AVAILABLE
 
         validation: Validation
         for validation in cred.validations:
             current_api_validation: KeyValidationOption = validation.verify(cred.line_data_list)
             if current_api_validation is KeyValidationOption.VALIDATED_KEY:
-                logging.debug(f"Valid validation by: {validation.__class__.__name__} for line: {cred.line_data_list[0].line}")
+                logging.debug(
+                    f"Valid validation by: {validation.__class__.__name__} for line: {cred.line_data_list[0].line}")
                 validation_option = current_api_validation
                 break
             if current_api_validation is KeyValidationOption.INVALID_KEY:
-                logging.debug(f"Invalid validation by: {validation.__class__.__name__} for line: {cred.line_data_list[0].line}")
+                logging.debug(
+                    f"Invalid validation by: {validation.__class__.__name__} for line: {cred.line_data_list[0].line}")
                 validation_option = current_api_validation
 
         return validation_option

--- a/credsweeper/validations/validation.py
+++ b/credsweeper/validations/validation.py
@@ -6,6 +6,7 @@ from credsweeper.credentials.line_data import LineData
 
 
 class Validation(ABC):
+
     @abstractmethod
     def verify(self, line_data_list: List[LineData]) -> KeyValidationOption:
         """Verify line_data_list with external API.


### PR DESCRIPTION
By the Google style guide it's required to have a blank line between a class declaration and the first function
(with class-docstring): https://google.github.io/styleguide/pyguide.html#384-classes
(no class-docstring): https://google.github.io/styleguide/pyguide.html#3193-forward-declarations 

Black lines between class docsting and fist func was added with https://github.com/Samsung/CredSweeper/pull/49
But yapf config was not updated, so some of this changes might be accidentally reverted back 

This PR changes:
- Update `yapf` config (`blank_line_before_nested_class_or_def`) so it would force an empty line between the class name and first function
- Rerun `yapf` on credsweeper dir
- Rerun `isort` on credsweeper dir