### PR TITLE
Add model threshold

### DIFF
--- a/credsweeper/common/constants.py
+++ b/credsweeper/common/constants.py
@@ -59,7 +59,6 @@ class RuleType(Enum):
 class ThresholdPreset(Enum):
     """Preset threshold to simplify precision/recall selection for the user."""
 
-    default = "default"
     lowest = "lowest"
     low = "low"
     medium = "medium"

--- a/credsweeper/common/constants.py
+++ b/credsweeper/common/constants.py
@@ -59,7 +59,12 @@ class RuleType(Enum):
 class ThresholdPreset(Enum):
     """Preset threshold to simplify precision/recall selection for the user."""
 
-    balanced = "balanced"
+    default = "default"
+    lowest = "lowest"
+    low = "low"
+    medium = "medium"
+    high = "high"
+    highest = "highest"
 
 
 class DiffRowType:

--- a/credsweeper/ml_model/ml_validator.py
+++ b/credsweeper/ml_model/ml_validator.py
@@ -26,7 +26,7 @@ from credsweeper.ml_model import features
 class MlValidator:
 
     @classmethod
-    def __init__(cls, threshold_preset: ThresholdPreset = ThresholdPreset.balanced) -> None:
+    def __init__(cls, threshold: Tuple[float, ThresholdPreset]) -> None:
         tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)  # To make TF logger quiet
         config = tf.compat.v1.ConfigProto()
         config.gpu_options.allow_growth = True  # dynamically grow the memory used on the GPU
@@ -44,8 +44,10 @@ class MlValidator:
         model_detail_path = f"{pathlib.Path(__file__).parent.absolute()}/model_config.json"
         with open(model_detail_path) as f:
             model_details = json.load(f)
-        if "thresholds" in model_details:
-            cls.threshold = model_details["thresholds"][threshold_preset.value]
+        if isinstance(threshold, float):
+            cls.threshold = threshold
+        elif isinstance(threshold, ThresholdPreset) and "thresholds" in model_details:
+            cls.threshold = model_details["thresholds"][threshold.value]
         else:
             cls.threshold = 0.5
         cls.maxlen = model_details.get("max_len", 50)

--- a/credsweeper/ml_model/model_config.json
+++ b/credsweeper/ml_model/model_config.json
@@ -1,6 +1,10 @@
 {
   "thresholds": {
-    "balanced": 0.5
+    "lowest": 0.22916731,
+    "low": 0.3573966,
+    "medium":  0.62203974,
+    "high": 0.7979102,
+    "highest": 0.9299587
   },
   "max_len": 50,
   "features": [

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -170,12 +170,10 @@ class TestApp:
         dir_path = os.path.dirname(os.path.realpath(__file__))
         target_path = os.path.join(dir_path, "samples", "password.patch")
         json_filename = "unittest_output.json"
-        proc = subprocess.Popen([
-            sys.executable, "-m", "credsweeper", "--diff_path", target_path, "--save-json", json_filename, "--log",
-            "silence"
-        ],
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "credsweeper", "--diff_path", target_path, "--save-json", json_filename, "--log", "silence"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
         _stdout, _stderr = proc.communicate()
 
         assert os.path.exists("unittest_output_added.json") and os.path.exists("unittest_output_deleted.json")
@@ -185,9 +183,10 @@ class TestApp:
     def test_patch_save_json_n(self) -> None:
         dir_path = os.path.dirname(os.path.realpath(__file__))
         target_path = os.path.join(dir_path, "samples", "password.patch")
-        proc = subprocess.Popen([sys.executable, "-m", "credsweeper", "--diff_path", target_path, "--log", "silence"],
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "credsweeper", "--diff_path", target_path, "--log", "silence"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
         _stdout, _stderr = proc.communicate()
 
         assert not os.path.exists("unittest_output_added.json") and not os.path.exists("unittest_output_deleted.json")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -10,6 +10,7 @@ from credsweeper.file_handler.text_content_provider import TextContentProvider
 
 
 class TestApp:
+
     def test_it_works_p(self) -> None:
         dir_path = os.path.dirname(os.path.realpath(__file__))
         target_path = os.path.join(dir_path, "samples", "password")
@@ -114,7 +115,7 @@ class TestApp:
         output = " ".join(stderr.decode("UTF-8").split())
 
         expected = """
-                   usage: python -m credsweeper [-h] (--path PATH [PATH ...] | --diff_path PATH [PATH ...]) [--rules [PATH]] [--ml_validation] [-b POSITIVE_INT] [--api_validation] [-j POSITIVE_INT] [--skip_ignored] [--save-json [PATH]] [-l LOG_LEVEL]
+                   usage: python -m credsweeper [-h] (--path PATH [PATH ...] | --diff_path PATH [PATH ...]) [--rules [PATH]] [--ml_validation] [--ml_threshold FLOAT_OR_STR] [-b POSITIVE_INT] [--api_validation] [-j POSITIVE_INT] [--skip_ignored] [--save-json [PATH]] [-l LOG_LEVEL]
                    python -m credsweeper: error: one of the arguments --path --diff_path is required
                    """
         expected = " ".join(expected.split())
@@ -169,10 +170,12 @@ class TestApp:
         dir_path = os.path.dirname(os.path.realpath(__file__))
         target_path = os.path.join(dir_path, "samples", "password.patch")
         json_filename = "unittest_output.json"
-        proc = subprocess.Popen(
-            [sys.executable, "-m", "credsweeper", "--diff_path", target_path, "--save-json", json_filename, "--log", "silence"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+        proc = subprocess.Popen([
+            sys.executable, "-m", "credsweeper", "--diff_path", target_path, "--save-json", json_filename, "--log",
+            "silence"
+        ],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
         _stdout, _stderr = proc.communicate()
 
         assert os.path.exists("unittest_output_added.json") and os.path.exists("unittest_output_deleted.json")
@@ -182,10 +185,9 @@ class TestApp:
     def test_patch_save_json_n(self) -> None:
         dir_path = os.path.dirname(os.path.realpath(__file__))
         target_path = os.path.join(dir_path, "samples", "password.patch")
-        proc = subprocess.Popen(
-            [sys.executable, "-m", "credsweeper", "--diff_path", target_path, "--log", "silence"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+        proc = subprocess.Popen([sys.executable, "-m", "credsweeper", "--diff_path", target_path, "--log", "silence"],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
         _stdout, _stderr = proc.communicate()
 
         assert not os.path.exists("unittest_output_added.json") and not os.path.exists("unittest_output_deleted.json")


### PR DESCRIPTION
Resolve #42 

Add ML thresholds based on best F-0.25 F-0.5 F-1 F-2 F-4 scores

Set default to medium (best F-1)

----------------

Threshold calculated from train repos in CredData:
```
    "lowest": 0.22916731,
    "low": 0.3573966,
    "medium":  0.62203974,
    "high": 0.7979102,
    "highest": 0.9299587
```
Current CredSweeper main branch on this thresholds:

Threshold|TP|FP|TN|FN|FPR|FNR|PRC|RCL|F1
-|-|-|-|-|-|-|-|-|-
0.22916731|3851|982|19453717|732|0.00005|0.15972|0.79681|0.84028|0.81797
0.3573966|3807|631|19454068|776|0.00003|0.16932|0.85782|0.83068|0.84403
**0.5 (current default)**|3739|440|19454259|844|0.00002|0.18416|0.89471|0.81584|0.85346
0.62203974|3662|319|19454380|921|0.00002|0.20096|0.91987|0.79904|0.85521
0.7979102|3444|170|19454529|1139|0.00001|0.24853|0.95296|0.75147|0.84031
0.9299587|3085|73|19454626|1498|0|0.32686|0.97688|0.67314|0.79705

----------------

For the reference:
`'password = "cackle!"'` in `tests/samples/password`
Have probability of `0.818`. So all thresholds but `highest` will detect it