### PR TITLE
Fix ResourceWarning in tests

### DIFF
--- a/credsweeper/secret/log.yaml
+++ b/credsweeper/secret/log.yaml
@@ -26,6 +26,7 @@ handlers:
         filename: ./log/credsweeper.log
         maxBytes: 50485760
         backupCount: 100
+        delay: True
 
     error_log:
         class: logging.handlers.RotatingFileHandler


### PR DESCRIPTION
Fix warning message in tests:

```
/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/importlib/_bootstrap.py:219: ResourceWarning: unclosed file <_io.FileIO name='/home/runner/work/CredSweeper/CredSweeper/credsweeper/log/credsweeper.log' mode='ab' closefd=True>
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

Fix based on:
https://stackoverflow.com/a/30684667

`delay: True` make that file only created on after at least 1 log message emitted
https://docs.python.org/3/library/logging.handlers.html#rotatingfilehandler
`If delay is true, then file opening is deferred until the first call to emit().`