### PR TITLE
Faster execution based on regex

### DIFF
--- a/credsweeper/common/constants.py
+++ b/credsweeper/common/constants.py
@@ -9,6 +9,8 @@ class KeywordPattern:
 
 class Separator:
     common = "=|:=|:"
+    # All unique non-regex characters from `common`
+    common_as_set = "=:"
     c = "="
     java = "="
     json = ":"
@@ -71,3 +73,9 @@ class DiffRowType:
     DELETED = "deleted"
     ADDED_ACCOMPANY = "added_accompany"
     DELETED_ACCOMPANY = "deleted_accompany"
+
+
+MIN_VARIABLE_LENGTH = 1
+MIN_SEPARATOR_LENGTH = 1
+MIN_VALUE_LENGTH = 4
+MAX_LINE_LENGTH = 1500

--- a/credsweeper/rules/config.yaml
+++ b/credsweeper/rules/config.yaml
@@ -6,6 +6,8 @@
   filter_type: GeneralKeyword
   use_ml: true
   validations: []
+  required_substrings:
+    - api
 
 - name: AWS Client ID
   severity: high
@@ -15,6 +17,9 @@
   filter_type: GeneralPattern
   use_ml: true
   validations: []
+  required_substrings:
+    - A
+  min_line_len: 20
 
 - name: AWS Multi
   severity: high
@@ -25,6 +30,10 @@
   filter_type: GeneralPattern
   use_ml: true
   validations: []
+  required_substrings:
+    - AKIA
+    - ASIA
+  min_line_len: 20
 
 - name: AWS MWS Key
   severity: high
@@ -34,6 +43,9 @@
   filter_type: GeneralPattern
   use_ml: true
   validations: []
+  required_substrings:
+    - amzn
+  min_line_len: 30
 
 - name: Credential
   severity: medium
@@ -43,6 +55,8 @@
   filter_type: GeneralKeyword
   use_ml: true
   validations: []
+  required_substrings:
+    - credential
 
 - name: Dynatrace API Token
   severity: high
@@ -52,6 +66,9 @@
   filter_type: GeneralPattern
   use_ml: true
   validations: []
+  required_substrings:
+    - dt0
+  min_line_len: 90
 
 - name: Facebook Access Token
   severity: high
@@ -61,6 +78,9 @@
   filter_type: GeneralPattern
   use_ml: true
   validations: []
+  required_substrings:
+    - EAACEdEose0cBA
+  min_line_len: 15
 
 - name: Github Old Token
   severity: high
@@ -71,6 +91,9 @@
   use_ml: true
   validations:
   - GithubTokenValidation
+  required_substrings:
+    - git
+  min_line_len: 47
 
 - name: Google API Key
   severity: high
@@ -81,6 +104,9 @@
   use_ml: true
   validations:
   - GoogleApiKeyValidation
+  required_substrings:
+    - AIza
+  min_line_len: 39
 
 - name: Google Multi
   severity: high
@@ -91,6 +117,9 @@
   filter_type: GeneralPattern
   use_ml: true
   validations: []
+  required_substrings:
+    - googleusercontent
+  min_line_len: 40
 
 - name: Google OAuth Access Token
   severity: high
@@ -100,6 +129,9 @@
   filter_type: GeneralPattern
   use_ml: true
   validations: []
+  required_substrings:
+    - ya29.
+  min_line_len: 6
 
 - name: Heroku API Key
   severity: high
@@ -109,6 +141,9 @@
   filter_type: GeneralPattern
   use_ml: true
   validations: []
+  required_substrings:
+    - heroku
+  min_line_len: 24
 
 - name: Instagram Access Token
   severity: high
@@ -118,6 +153,9 @@
   filter_type: GeneralPattern
   use_ml: true
   validations: []
+  required_substrings:
+    - IGQVJ
+  min_line_len: 105
 
 - name: JSON Web Token
   severity: medium
@@ -127,6 +165,9 @@
   filter_type: GeneralPattern
   use_ml: true
   validations: []
+  required_substrings:
+    - .eyJ
+  min_line_len: 9
 
 - name: MailChimp API Key
   severity: high
@@ -137,6 +178,9 @@
   use_ml: true
   validations:
   - MailChimpKeyValidation
+  required_substrings:
+    - -us
+  min_line_len: 35
 
 - name: MailGun API Key
   severity: high
@@ -146,6 +190,9 @@
   filter_type: GeneralPattern
   use_ml: true
   validations: []
+  required_substrings:
+    - key-
+  min_line_len: 36
 
 - name: Password
   severity: medium
@@ -155,6 +202,9 @@
   filter_type: PasswordKeyword
   use_ml: true
   validations: []
+  required_substrings:
+    - pass
+    - pwd
 
 - name: PayPal Braintree Access Token
   severity: high
@@ -164,6 +214,9 @@
   filter_type: GeneralPattern
   use_ml: true
   validations: []
+  required_substrings:
+    - access_token
+  min_line_len: 72
 
 - name: PEM Certificate
   severity: high
@@ -182,6 +235,9 @@
   filter_type: GeneralPattern
   use_ml: true
   validations: []
+  required_substrings:
+    - sk_live_
+  min_line_len: 40
 
 - name: Secret
   severity: medium
@@ -191,6 +247,8 @@
   filter_type: GeneralKeyword
   use_ml: true
   validations: []
+  required_substrings:
+    - secret
 
 - name: SendGrid API Key
   severity: high
@@ -200,6 +258,9 @@
   filter_type: GeneralPattern
   use_ml: true
   validations: []
+  required_substrings:
+    - SG.
+  min_line_len: 34
 
 - name: Shopify Token
   severity: high
@@ -209,6 +270,9 @@
   filter_type: GeneralPattern
   use_ml: true
   validations: []
+  required_substrings:
+    - shp
+  min_line_len: 38
 
 - name: Slack Token
   severity: high
@@ -219,6 +283,9 @@
   use_ml: true
   validations:
   - SlackTokenValidation
+  required_substrings:
+    - xox
+  min_line_len: 15
 
 - name: Slack Webhook
   severity: high
@@ -228,6 +295,9 @@
   filter_type: GeneralPattern
   use_ml: true
   validations: []
+  required_substrings:
+    - slack
+  min_line_len: 61
 
 - name: Stripe Standard API Key
   severity: high
@@ -238,6 +308,9 @@
   use_ml: true
   validations:
   - StripeApiKeyValidation
+  required_substrings:
+    - sk_live_
+  min_line_len: 32
 
 - name: Stripe Restricted API Key
   severity: high
@@ -247,6 +320,9 @@
   filter_type: GeneralPattern
   use_ml: true
   validations: []
+  required_substrings:
+    - rk_live_
+  min_line_len: 32
 
 - name: Square Access Token
   severity: high
@@ -257,6 +333,9 @@
   use_ml: true
   validations:
   - SquareAccessTokenValidation
+  required_substrings:
+    - EAAA
+  min_line_len: 64
 
 - name: Square Client ID
   severity: medium
@@ -267,6 +346,9 @@
   use_ml: true
   validations:
   - SquareClientIdValidation
+  required_substrings:
+    - sq0
+  min_line_len: 29
 
 - name: Square OAuth Secret
   severity: high
@@ -276,6 +358,9 @@
   filter_type: GeneralPattern
   use_ml: true
   validations: []
+  required_substrings:
+    - sq0csp
+  min_line_len: 50
 
 - name: Token
   severity: medium
@@ -285,6 +370,8 @@
   filter_type: GeneralKeyword
   use_ml: true
   validations: []
+  required_substrings:
+    - token
 
 - name: Twilio API Key
   severity: high
@@ -294,6 +381,9 @@
   filter_type: GeneralPattern
   use_ml: true
   validations: []
+  required_substrings:
+    - SK
+  min_line_len: 34
 
 - name: URL Credentials
   severity: high
@@ -303,6 +393,9 @@
   filter_type: UrlCredentialsGroup
   use_ml: true
   validations: []
+  required_substrings:
+    - //
+  min_line_len: 6
 
 - name: Auth
   severity: medium
@@ -312,6 +405,8 @@
   filter_type: GeneralKeyword
   use_ml: true
   validations: []
+  required_substrings:
+    - auth
 
 - name: Key
   severity: medium
@@ -321,6 +416,8 @@
   filter_type: GeneralKeyword
   use_ml: true
   validations: []
+  required_substrings:
+    - key
 
 - name: Telegram Bot API Token
   severity: high
@@ -330,6 +427,9 @@
   filter_type: GeneralPattern
   use_ml: false
   validations: []
+  required_substrings:
+    - :AA
+  min_line_len: 45
 
 - name: PyPi API Token
   severity: high
@@ -339,6 +439,9 @@
   filter_type: GeneralPattern
   use_ml: false
   validations: []
+  required_substrings:
+    - pypi
+  min_line_len: 155
 
 - name: Github Token
   severity: high
@@ -348,6 +451,9 @@
   filter_type: GeneralPattern
   use_ml: false
   validations: []
+  required_substrings:
+    - gh
+  min_line_len: 40
 
 - name: Github Personal Access Token
   severity: high
@@ -358,6 +464,9 @@
   use_ml: false
   validations:
   - GithubTokenValidation
+  required_substrings:
+    - ghp_
+  min_line_len: 40
 
 - name: Firebase Domain
   severity: info
@@ -367,6 +476,9 @@
   filter_type: GeneralPattern
   use_ml: false
   validations: []
+  required_substrings:
+    - firebase
+  min_line_len: 16
 
 - name: AWS S3 Bucket
   severity: info
@@ -376,6 +488,10 @@
   filter_type: GeneralPattern
   use_ml: false
   validations: []
+  required_substrings:
+    - s3-website
+    - amazonaws
+  min_line_len: 14
 
 - name: Nonce
   severity: medium
@@ -385,6 +501,8 @@
   filter_type: GeneralKeyword
   use_ml: true
   validations: []
+  required_substrings:
+    - nonce
 
 - name: Salt
   severity: medium
@@ -394,6 +512,8 @@
   filter_type: GeneralKeyword
   use_ml: true
   validations: []
+  required_substrings:
+    - salt
 
 - name: Certificate
   severity: medium
@@ -403,3 +523,5 @@
   filter_type: GeneralKeyword
   use_ml: true
   validations: []
+  required_substrings:
+    - cert

--- a/credsweeper/scanner/scan_type/scan_type.py
+++ b/credsweeper/scanner/scan_type/scan_type.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 
 from regex import regex
 
+from credsweeper.common.constants import MAX_LINE_LENGTH
 from credsweeper.config import Config
 from credsweeper.credentials import Candidate, LineData
 from credsweeper.filters import Filter
@@ -19,8 +20,6 @@ class ScanType(ABC):
         MAX_LINE_LENGTH: Int constant. Max line length allowed in Scanner. All lines longer than this will be ignored
 
     """
-
-    MAX_LINE_LENGTH = 1500
 
     @classmethod
     @abstractmethod
@@ -136,6 +135,6 @@ class ScanType(ABC):
             Boolean. True if line is not too long. False otherwise
 
         """
-        if len(line) <= cls.MAX_LINE_LENGTH:
+        if len(line) <= MAX_LINE_LENGTH:
             return True
         return False

--- a/credsweeper/scanner/scanner.py
+++ b/credsweeper/scanner/scanner.py
@@ -66,17 +66,20 @@ class Scanner:
             # Ignore target if it's too long
             if len(target.line) > MAX_LINE_LENGTH:
                 continue
-            # Ignore target if it's too long
+            # Trim string from outer spaces to make future `a in str` checks faster
             target_line_trimmed = target.line.strip()
             target_line_trimmed_len = len(target_line_trimmed)
-            # Ignore target if part trimmed from spaces is too short
+            # Ignore target if trimmed part is too short
             if target_line_trimmed_len < self.min_len:
                 continue
             target_line_trimmed_lower = target_line_trimmed.lower()
+            # Check if have at least one separator character. Otherwise cannot be matched by a keyword
             if any(x in target_line_trimmed for x in Separator.common_as_set):
                 keyword_targets.append((target, target_line_trimmed_lower, target_line_trimmed_len))
+            # Check if have length not smaller than smallest `min_line_len` in all pattern rules
             if target_line_trimmed_len >= self.min_pattern_len:
                 pattern_targets.append((target, target_line_trimmed_lower, target_line_trimmed_len))
+            # Check if have "BEGIN" substring. Cannot otherwise ba matched as a PEM key
             if "BEGIN" in target_line_trimmed:
                 pem_targets.append((target, target_line_trimmed_lower, target_line_trimmed_len))
 

--- a/credsweeper/scanner/scanner.py
+++ b/credsweeper/scanner/scanner.py
@@ -1,8 +1,10 @@
 import os
-from typing import List, Optional, Type
+from typing import List, Optional, Type, Tuple
 
 import yaml
 
+from credsweeper.common.constants import RuleType, MIN_VARIABLE_LENGTH, MIN_SEPARATOR_LENGTH, MIN_VALUE_LENGTH, \
+    MAX_LINE_LENGTH, Separator
 from credsweeper.config import Config
 from credsweeper.credentials import Candidate
 from credsweeper.file_handler.analysis_target import AnalysisTarget
@@ -16,12 +18,19 @@ class Scanner:
 
     Attributes:
         rules: list of rule objects to check
+        min_pattern_len: minimal length specified in all pattern rules
+        min_keyword_len: minimal possible length for a string to be matched by any keyword rule
+        min_len: Smallest between min_pattern_len and min_keyword_len
+        TargetGroup: Type for List[Tuple[AnalysisTarget, str, int]]
 
     """
+
+    TargetGroup = List[Tuple[AnalysisTarget, str, int]]
 
     def __init__(self, config: Config, rule_path: Optional[str]) -> None:
         self.config = config
         self._set_rules(rule_path)
+        self.__scanner_for_rule = {rule.rule_name: self.get_scanner(rule) for rule in self.rules}
 
     def _set_rules(self, rule_path: Optional[str]) -> None:
         self.rules: List[Rule] = []
@@ -32,6 +41,46 @@ class Scanner:
             rule_templates = yaml.load(f, Loader=yaml.Loader)
         for rule_template in rule_templates:
             self.rules.append(Rule(self.config, rule_template))
+        self.min_pattern_len = 999
+        for rule in self.rules:
+            if rule.rule_type == RuleType.PATTERN:
+                self.min_pattern_len = min(self.min_pattern_len, rule.min_line_len)
+        self.min_keyword_len = MIN_VARIABLE_LENGTH + MIN_SEPARATOR_LENGTH + MIN_VALUE_LENGTH
+        self.min_len = min(self.min_keyword_len, self.min_pattern_len)
+
+    def _select_and_group_targets(self, targets: List[AnalysisTarget]) -> Tuple[TargetGroup, TargetGroup, TargetGroup]:
+        """Group targets into 3 lists based on loaded rules.
+
+        Args:
+            targets: List of AnalysisTarget to analyze
+
+        Return:
+            Three TargetGroup objects: one for keywords, one for patterns, and one for PEM keys
+
+        """
+        keyword_targets = []
+        pattern_targets = []
+        pem_targets = []
+
+        for target in targets:
+            # Ignore target if it's too long
+            if len(target.line) > MAX_LINE_LENGTH:
+                continue
+            # Ignore target if it's too long
+            target_line_trimmed = target.line.strip()
+            target_line_trimmed_len = len(target_line_trimmed)
+            # Ignore target if part trimmed from spaces is too short
+            if target_line_trimmed_len < self.min_len:
+                continue
+            target_line_trimmed_lower = target_line_trimmed.lower()
+            if any(x in target_line_trimmed for x in Separator.common_as_set):
+                keyword_targets.append((target, target_line_trimmed_lower, target_line_trimmed_len))
+            if target_line_trimmed_len >= self.min_pattern_len:
+                pattern_targets.append((target, target_line_trimmed_lower, target_line_trimmed_len))
+            if "BEGIN" in target_line_trimmed:
+                pem_targets.append((target, target_line_trimmed_lower, target_line_trimmed_len))
+
+        return keyword_targets, pattern_targets, pem_targets
 
     def scan(self, targets: List[AnalysisTarget]) -> List[Candidate]:
         """Run scanning of list of target lines from 'targets' with set of rule from 'self.rules'.
@@ -45,10 +94,21 @@ class Scanner:
 
         """
         credentials = []
+        keyword_targets, pattern_targets, pem_targets = self._select_and_group_targets(targets)
         for rule in self.rules:
-            for target in targets:
-                new_credential = self.get_scanner(rule).run(self.config, target.line, target.line_num, target.file_path,
-                                                            rule, target.lines)
+            min_line_len = rule.min_line_len
+            required_substrings = rule.required_substrings
+            scanner = self.__scanner_for_rule[rule.rule_name]
+            to_check = self.get_targets_to_check(keyword_targets, pattern_targets, pem_targets, rule)
+            # It is almost two times faster to precompute values related to target_line than to compute them in
+            # each iteration
+            for target, target_line_trimmed_lower, target_line_trimmed_len in to_check:
+                if target_line_trimmed_len < min_line_len:
+                    continue
+                if not any(substring in target_line_trimmed_lower for substring in required_substrings):
+                    continue
+                new_credential = scanner.run(self.config, target.line, target.line_num, target.file_path, rule,
+                                             target.lines)
                 if new_credential:
                     logging.debug(
                         f"Credential for rule: {rule.rule_name} in file: {target.file_path}:{target.line_num} in line: {target.line}"
@@ -74,3 +134,27 @@ class Scanner:
         elif rule.pattern_type == Rule.PEM_KEY_PATTERN:
             return PemKeyPattern
         raise ValueError(f"Unknown pattern_type in rule: {rule.pattern_type}")
+
+    @staticmethod
+    def get_targets_to_check(keyword_targets: TargetGroup, pattern_targets: TargetGroup, pem_targets: TargetGroup,
+                             rule: Rule) -> TargetGroup:
+        """Choose target subset based on a rule.
+
+        Args:
+            keyword_targets: TargetGroup with targets relevant to a keyword based rules
+            pattern_targets: TargetGroup with targets relevant to a pattern based rules
+            pem_targets: TargetGroup with targets relevant to a pem key rules
+            rule: rule object used to scanning
+
+        Return:
+            depending on the rule type, returns one of the other arguments
+
+        """
+        if rule.rule_type == RuleType.KEYWORD:
+            return keyword_targets
+        elif rule.rule_type == RuleType.PATTERN:
+            return pattern_targets
+        elif rule.rule_type == RuleType.PEM_KEY:
+            return pem_targets
+        else:
+            raise ValueError(f"Unknown RuleType {rule.rule_type}")


### PR DESCRIPTION
**Summary**:
- This PR improves execution time 5-7 times (based on repo under a scan) without any change to the output

Current main branch:
```bash
 time python -m credsweeper --path CredData/data/ -j 16 --save-json dataset_main.json

real    7m34,493s
user    30m57,242s
sys     0m3,632s
```

With this change:
```bash
$ time python -m credsweeper --path CredData/data/ -j 16 --save-json dataset_fast.json

real    1m23,158s
user    5m16,442s
sys     0m3,064s
```

Output is identical:
```bash
$ cmp --silent dataset_main.json dataset_faster.json && echo '### SUCCESS: Files Are Identical! ###' || echo '### WARNING: Files Are Different! ###'
### SUCCESS: Files Are Identical! ###


$ wc -l dataset_main.json && tail -10 dataset_main.json
385218 dataset_main.json
                "value": "b03f5f7f11d50a3a",
                "variable": "PublicKeyToken",
                "entropy_validation": true
            }
        ],
        "ml_probability": null,
        "rule": "Key",
        "severity": "medium"
    }
]

$ wc -l dataset_faster.json && tail -10 dataset_faster.json
385218 dataset_faster.json
                "value": "b03f5f7f11d50a3a",
                "variable": "PublicKeyToken",
                "entropy_validation": true
            }
        ],
        "ml_probability": null,
        "rule": "Key",
        "severity": "medium"
    }

```

-----------------------------------

**Idea**:
Regex engines in python are not very fast. Nearly ~80-90% of CredSweeper execution time spent on single `pattern.search(line)` line
So it would be nicer to find a way to call to regex less
This PR introduce new fields for each rule: `required_substrings` and `min_line_len`
Idea is that if none of lines in `required_substrings` is not present in line under scan, or line length less than `min_line_len` - line would not be regexed under the given rule

`required_substrings` is a substring that is a part of regex itself, and regex would never be matched in line unless this substring is also present
Example:
- For rule api `required_substrings` is `api`
- During execution, api rule would create regex `(?P<variable>(((\'|\\"|`)[^:=\'\\"`<>]*|[^:=\'\\"`<>\\s\\(]*)(?P<keyword>api)[^:=\'\\"`<>]*)(\'|\\"|`)?)\\s*\\]?\\s*(?P<separator>=|:=|:)((\\s|\\w)*\\((\\s|\\w|=|\\()*|\\s*)(?P<value_leftquote>(\\\\)*(b|r)?(\'|\\"|`))?(?P<value>[^\'\\"`(\\\\\\\')(\\\\\\")]{0,1000})(?P<value_rightquote>(\\\\)*(\'|\\"|`))?`
- this regex cannot possible match if line do not have word `api` in it
- we check `if "api" in line`, and if not - no point in running regex at all

`min_line_len` is a minimal possible length that rule require to match it's regex. There is no point in processing line with this rule if number characters is less than this value 
Example:
- Rule `Github Personal Access Token` have regex `(?P<value>ghp_[\w]{36,255})`
- This regex require at least  40 characters to match (`len("ghp_") + 36`)
- If `len(line) < 40` no point in running regex with this line

Exact change list:
- Add `min_line_len` and `required_substrings` for most rules
- `min_line_len` and `required_substrings` can missing from some rules - than this rules would be processed in old way
- Add `Separator.common_as_set` - set of possible separators. Keyword rules require a separator in regex, so if no such character in a line - no point in running regex
- Move `MAX_LINE_LENGTH` to `constants.py`
- Make `scanner.py` use the new field
- Refactor `Scanner.scan` function to make it do less redundant calls
