### PR TITLE
Remove non-existing attributes from docstring

### DIFF
--- a/credsweeper/scanner/scan_type/multi_pattern.py
+++ b/credsweeper/scanner/scan_type/multi_pattern.py
@@ -10,7 +10,6 @@ class MultiPattern(ScanType):
     """Check if line is a part of a multi-line credential and second part is present within MAX_SEARCH_MARGIN lines.
 
     Attributes:
-        MAX_LINE_LENGTH: Int constant. Max line length allowed in Scanner. All lines longer than this will be ignored
         MAX_SEARCH_MARGIN: Int constant. Number of lines around current to perform search for the second part
 
     """

--- a/credsweeper/scanner/scan_type/pem_key_pattern.py
+++ b/credsweeper/scanner/scan_type/pem_key_pattern.py
@@ -12,7 +12,6 @@ class PemKeyPattern(ScanType):
     """Check if line is a start of a PEM key.
 
     Attributes:
-        MAX_LINE_LENGTH: Int constant. Max line length allowed in Scanner. All lines longer than this will be ignored
         ignore_starts: Leading lines in pem file that should be ignored
         remove_characters: This characters would be striped from PEM lines before entropy check
 

--- a/credsweeper/scanner/scan_type/scan_type.py
+++ b/credsweeper/scanner/scan_type/scan_type.py
@@ -16,9 +16,6 @@ class ScanType(ABC):
 
     Scanner allow to check if regex pattern defined in a rule is present in a line.
 
-    Attributes:
-        MAX_LINE_LENGTH: Int constant. Max line length allowed in Scanner. All lines longer than this will be ignored
-
     """
 
     @classmethod

--- a/credsweeper/scanner/scan_type/single_pattern.py
+++ b/credsweeper/scanner/scan_type/single_pattern.py
@@ -7,12 +7,7 @@ from credsweeper.scanner.scan_type import ScanType
 
 
 class SinglePattern(ScanType):
-    """Check if single line rule present in the line.
-
-    Attributes:
-        MAX_LINE_LENGTH: Int constant. Max line length allowed in Scanner. All lines longer than this will be ignored
-
-    """
+    """Check if single line rule present in the line."""
 
     @classmethod
     def run(cls, config: Config, line: str, line_num: int, file_path: str, rule: Rule,


### PR DESCRIPTION
`MAX_LINE_LENGTH` attribute do not exists in files in `credsweeper/scanner/scan_type/`

`MAX_LINE_LENGTH` do exist, but in the constants:
https://github.com/Samsung/CredSweeper/blob/f82629d5c065e34c99f79035db370d566d58204c/credsweeper/common/constants.py#L81

So it's better to remove this attributes from files in `credsweeper/scanner/scan_type/`, as they are providing a false information

