### PR TITLE
Limit TF version by 2.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
 ml_requires = [
     "numpy",
     "scikit-learn",
-    "tensorflow>=2.3.0, !=2.6.0, !=2.6.1"
+    "tensorflow>=2.3.0, !=2.6.0, !=2.6.1, <2.8.0"
 ]
 
 setuptools.setup(


### PR DESCRIPTION
Newly released TF 2.8.0 have a different Keras API

Until new API implemented in the code, this PR limit the TF version to `<2.8.0`

```
$ python -m credsweeper --path tests/samples/password --ml_validation
Traceback (most recent call last):
  File "/home/user/share/code/credsweeper_replicas/meanrin/CredSweeper/credsweeper/ml_model/ml_validator.py", line 12, in <module>
    from tensorflow.python.keras.preprocessing.sequence import pad_sequences
ModuleNotFoundError: No module named 'tensorflow.python.keras.preprocessing'
```

![image](https://user-images.githubusercontent.com/43581724/152345718-9a8e5159-00f8-451c-8920-2d9a34fdfbd9.png)
