### PR TITLE
Single job by default

### DIFF
--- a/credsweeper/__main__.py
+++ b/credsweeper/__main__.py
@@ -69,9 +69,10 @@ def get_arguments() -> ArgumentParser.parse_args:
                         action="store_true")
     parser.add_argument("-j",
                         "--jobs",
-                        help="number of parallel processes to use (default: number of CPU cores * 2)",
+                        help="number of parallel processes to use (default: 1)",
                         type=positive_int,
                         dest="jobs",
+                        default=1,
                         metavar="POSITIVE_INT")
     parser.add_argument("--skip_ignored",
                         help="parse .gitignore files and skip credentials from ignored objects",

--- a/credsweeper/app.py
+++ b/credsweeper/app.py
@@ -21,7 +21,7 @@ class CredSweeper:
     Parameters:
         credential_manager: CredSweeper credential manager object
         scanner: CredSweeper scanner object
-        POOL_COUNT: number of pools used to run multiprocessing scanning
+        pool_count: number of pools used to run multiprocessing scanning
         config: dictionary variable, stores analyzer features
         json_filename: string variable, credential candidates export filename
 
@@ -33,7 +33,7 @@ class CredSweeper:
                  api_validation: bool = False,
                  json_filename: Optional[str] = None,
                  use_filters: bool = True,
-                 pool_count: Optional[int] = None,
+                 pool_count: int = 1,
                  ml_batch_size: Optional[int] = 16,
                  ml_threshold: Optional[Tuple[float, ThresholdPreset]] = None) -> None:
         """Initialize Advanced credential scanner.
@@ -52,9 +52,7 @@ class CredSweeper:
             ml_threshold: float or string value to specify threshold for the ml model
 
         """
-        if pool_count is None:
-            pool_count = self.__get_pool_count()
-        self.pool_count: int = pool_count
+        self.pool_count: int = pool_count if pool_count > 1 else 1
         dir_path = os.path.dirname(os.path.realpath(__file__))
         with open(os.path.join(dir_path, "secret", "config.json"), "r", encoding=DEFAULT_ENCODING) as conf_file:
             config_dict = json.load(conf_file)
@@ -69,16 +67,6 @@ class CredSweeper:
         self.json_filename: Optional[str] = json_filename
         self.ml_batch_size = ml_batch_size
         self.ml_threshold = ml_threshold
-
-    def __get_pool_count(self) -> int:
-        """Get the number of pools based on doubled CPUs in the system."""
-        if self.__is_pytest_running():
-            return 1
-        return os.cpu_count() * 2
-
-    def __is_pytest_running(self) -> bool:
-        """Check for running the module as part of testing."""
-        return "pytest_cov" in sys.modules
 
     def pool_initializer(self) -> None:
         """Ignore SIGINT in child processes."""

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -30,7 +30,7 @@ Get all argument list:
                             batch size for model inference (default: 16)
     --api_validation      Add credential api validation option to credsweeper pipeline. External API is used to reduce FP for some rule types.
     -j POSITIVE_INT, --jobs POSITIVE_INT
-                            number of parallel processes to use (default: number of CPU cores * 2)
+                            number of parallel processes to use (default: 1)
     --skip_ignored        parse .gitignore files and skip credentials from ignored objects
     --save-json [PATH]    save result to json file (default: output.json)
     -l LOG_LEVEL, --log LOG_LEVEL

--- a/docs/source/overall_architecture.rst
+++ b/docs/source/overall_architecture.rst
@@ -37,7 +37,7 @@ Scan
 ----
 
 
-Basically, scanning is performed for each file path with a pool of cpu core * 2, and it is performed based on the Rule_s. Scanning method differs from scan type of the Rule_, which is assigned when the Rule_ is generated. There are 3 scan types: `SinglePattern <_modules/scanner/scan_type/single_pattern.html>`_, `MultiPattern <_modules/scanner/scan_type/multi_pattern.html>`_, and `PEMKeyPattern <_modules/scanner/scan_type/pem_key_pattern.html>`_. Below is the description of the each scan type and its scanning method.
+Basically, scanning is performed for each file path, and it is performed based on the Rule_s. Scanning method differs from scan type of the Rule_, which is assigned when the Rule_ is generated. There are 3 scan types: `SinglePattern <_modules/scanner/scan_type/single_pattern.html>`_, `MultiPattern <_modules/scanner/scan_type/multi_pattern.html>`_, and `PEMKeyPattern <_modules/scanner/scan_type/pem_key_pattern.html>`_. Below is the description of the each scan type and its scanning method.
 
 - `SinglePattern <_modules/scanner/scan_type/single_pattern.html>`_
   - When : The Rule_ has only 1 pattern.


### PR DESCRIPTION
Multiple jobs do overhead with creating new processes and not speedup time.

Some tests results:

Start: 1643570067.692241777 Stop: 1643570404.724208434 Elapsed (seconds): 337.031966657
1 jobs calculates lines per second:10349.08657062116809152130

Start with job_cfg='-j 2'
Start: 1643570404.734513404 Stop: 1643570676.303738281 Elapsed (seconds): 271.569224877
2 jobs calculates lines per second:12843.77123946862485045807

Start with job_cfg='-j 4'
Start: 1643570676.315110215 Stop: 1643570905.733240183 Elapsed (seconds): 229.418129968
4 jobs calculates lines per second:15203.56303351663627051851

Start with job_cfg='-j 8'
Start: 1643570905.745620467 Stop: 1643571128.117708713 Elapsed (seconds): 222.372088246
8 jobs calculates lines per second:15685.30037880210985298964

Start with job_cfg='-j 10'
Start: 1643571128.128947618 Stop: 1643571348.108680366 Elapsed (seconds): 219.979732748
10 jobs calculates lines per second:15855.88343266005611994416

May be there is file IO issue or multiprocessing, so let user decide how many processes should work on specific platform.