### PR TITLE
Add if to support new keras imports in TF 2.8.0

### DIFF
--- a/credsweeper/ml_model/ml_validator.py
+++ b/credsweeper/ml_model/ml_validator.py
@@ -4,6 +4,8 @@ import pathlib
 import string
 from typing import List, Tuple, Union
 
+from pkg_resources import parse_version
+
 from credsweeper.common.constants import ThresholdPreset, DEFAULT_ENCODING
 from credsweeper.credentials import Candidate
 from credsweeper.logger.logger import logging
@@ -12,11 +14,16 @@ ML_VALIDATOR_IMPORT_ERROR = "Start importing"
 try:
     import numpy as np
     import tensorflow as tf
-    from tensorflow.keras import models
     from tensorflow.python.keras.backend import set_session
-    from tensorflow.python.keras.preprocessing.sequence import pad_sequences
     from tensorflow.python.keras.utils.np_utils import to_categorical
     from credsweeper.ml_model import features
+
+    if parse_version(tf.__version__) < parse_version("2.8.0"):
+        from tensorflow.keras import models
+        from tensorflow.python.keras.preprocessing.sequence import pad_sequences
+    else:
+        from keras import models
+        from keras.preprocessing.sequence import pad_sequences
 
     ML_VALIDATOR_IMPORT_ERROR = None
 except ModuleNotFoundError as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ PyYAML==5.4.1
 regex==2021.8.3
 requests==2.25.1
 scikit-learn==0.24.1
-tensorflow==2.7.1
+tensorflow==2.8.0
 toml==0.10.2
 yapf==0.30.0
 nltk==3.6.6

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
 ml_requires = [
     "numpy",
     "scikit-learn",
-    "tensorflow>=2.3.0, !=2.6.0, !=2.6.1, !=2.6.2, <2.8.0"
+    "tensorflow>=2.3.0, !=2.6.0, !=2.6.1, !=2.6.2, <2.9.0"
 ]
 
 setuptools.setup(


### PR DESCRIPTION
Related to: https://github.com/Samsung/CredSweeper/pull/72 

Due to the change in keras library location in tf 2.8.0:
- Add if to check tf version
- Add different imports for 2.8 and prior versions 