### PR TITLE
Fix type errors in __main__.py

### DIFF
--- a/credsweeper/__main__.py
+++ b/credsweeper/__main__.py
@@ -1,9 +1,10 @@
 import os
-from argparse import ArgumentParser, ArgumentTypeError
+from argparse import ArgumentParser, ArgumentTypeError, Namespace
 from typing import Any
 
 from credsweeper.app import CredSweeper
 from credsweeper.common.constants import ThresholdPreset
+from credsweeper.file_handler.files_provider import FilesProvider
 from credsweeper.file_handler.patch_provider import PatchProvider
 from credsweeper.file_handler.text_provider import TextProvider
 from credsweeper.logger.logger import Logger, logging
@@ -29,7 +30,7 @@ def threshold_or_float(arg):
     raise ArgumentTypeError(f"value must be a float or one of {allowed_presents}")
 
 
-def get_arguments() -> ArgumentParser.parse_args:
+def get_arguments() -> Namespace:
     parser = ArgumentParser(prog="python -m credsweeper")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--path", nargs="+", help="file or directory to scan", dest="path", metavar="PATH")
@@ -120,7 +121,7 @@ def main() -> None:
     logging.info(f"Init CredSweeper object with arguments: {args}")
     if args.path:
         logging.info(f"Run analyzer on path: {args.path}")
-        content_provider = TextProvider(args.path, skip_ignored=args.skip_ignored)
+        content_provider: FilesProvider = TextProvider(args.path, skip_ignored=args.skip_ignored)
         scan(args, content_provider, args.json_filename)
     if args.diff_path:
         added_json_filename, deleted_json_filename = get_json_filenames(args.json_filename)


### PR DESCRIPTION
I fixed below type hint errors in `__main__.py`
```
credsweeper/__main__.py:32: error: Function "argparse.ArgumentParser.parse_args" is not valid as a type
credsweeper/__main__.py:32: note: Perhaps you need "Callable[...]" or a callback protocol?
credsweeper/__main__.py:118: error: ArgumentParser.parse_args? has no attribute "log"
credsweeper/__main__.py:119: error: ArgumentParser.parse_args? has no attribute "log"
credsweeper/__main__.py:121: error: ArgumentParser.parse_args? has no attribute "path"
credsweeper/__main__.py:122: error: ArgumentParser.parse_args? has no attribute "path"
credsweeper/__main__.py:123: error: ArgumentParser.parse_args? has no attribute "path"
credsweeper/__main__.py:123: error: ArgumentParser.parse_args? has no attribute "skip_ignored"
credsweeper/__main__.py:124: error: ArgumentParser.parse_args? has no attribute "json_filename"
credsweeper/__main__.py:125: error: ArgumentParser.parse_args? has no attribute "diff_path"
credsweeper/__main__.py:126: error: ArgumentParser.parse_args? has no attribute "json_filename"
credsweeper/__main__.py:128: error: ArgumentParser.parse_args? has no attribute "diff_path"
credsweeper/__main__.py:129: error: Incompatible types in assignment (expression has type "PatchProvider", variable has type "TextProvider")                                                                                   
credsweeper/__main__.py:129: error: ArgumentParser.parse_args? has no attribute "diff_path"
credsweeper/__main__.py:132: error: ArgumentParser.parse_args? has no attribute "diff_path"
credsweeper/__main__.py:133: error: Incompatible types in assignment (expression has type "PatchProvider", variable has type "TextProvider")                                                                                   
credsweeper/__main__.py:133: error: ArgumentParser.parse_args? has no attribute "diff_path"                                                                             
```