### PR TITLE
Add find by ext option

### DIFF
--- a/credsweeper/__main__.py
+++ b/credsweeper/__main__.py
@@ -113,7 +113,8 @@ def scan(args, content_provider, json_filename):
                               json_filename=json_filename,
                               pool_count=args.jobs,
                               ml_batch_size=args.ml_batch_size,
-                              ml_threshold=args.ml_threshold)
+                              ml_threshold=args.ml_threshold,
+                              find_by_ext=args.find_by_ext)
     credsweeper.run(content_provider=content_provider)
 
 

--- a/credsweeper/__main__.py
+++ b/credsweeper/__main__.py
@@ -40,8 +40,12 @@ def get_arguments() -> ArgumentParser.parse_args:
                         default=None,
                         dest="rule_path",
                         metavar="PATH")
+    parser.add_argument("--find-by-ext",
+                        help="find files by predefined extension.",
+                        dest="find_by_ext",
+                        action="store_true")
     parser.add_argument("--ml_validation",
-                        help="Use credential ml validation option. Machine Learning is used to reduce FP (by far).",
+                        help="use credential ml validation option. Machine Learning is used to reduce FP (by far).",
                         dest="ml_validation",
                         action="store_true")
     parser.add_argument("--ml_threshold",
@@ -63,7 +67,7 @@ def get_arguments() -> ArgumentParser.parse_args:
                         required=False,
                         metavar="POSITIVE_INT")
     parser.add_argument("--api_validation",
-                        help="Add credential api validation option to credsweeper pipeline. "
+                        help="add credential api validation option to credsweeper pipeline. "
                         "External API is used to reduce FP for some rule types.",
                         dest="api_validation",
                         action="store_true")

--- a/credsweeper/app.py
+++ b/credsweeper/app.py
@@ -6,10 +6,13 @@ import signal
 import sys
 from typing import Dict, List, Optional, Tuple
 
-from credsweeper.common.constants import KeyValidationOption, ThresholdPreset, DEFAULT_ENCODING
+import regex
+
+from credsweeper.common.constants import KeyValidationOption, ThresholdPreset, DEFAULT_ENCODING, Severity
 from credsweeper.config import Config
-from credsweeper.credentials import Candidate, CredentialManager
+from credsweeper.credentials import Candidate, CredentialManager, LineData
 from credsweeper.file_handler.content_provider import ContentProvider
+from credsweeper.file_handler.file_path_extractor import FilePathExtractor
 from credsweeper.logger.logger import logging
 from credsweeper.scanner import Scanner
 from credsweeper.validations.apply_validation import ApplyValidation
@@ -26,7 +29,6 @@ class CredSweeper:
         json_filename: string variable, credential candidates export filename
 
     """
-
     def __init__(self,
                  rule_path: Optional[str] = None,
                  ml_validation: bool = False,
@@ -35,7 +37,8 @@ class CredSweeper:
                  use_filters: bool = True,
                  pool_count: int = 1,
                  ml_batch_size: Optional[int] = 16,
-                 ml_threshold: Optional[Tuple[float, ThresholdPreset]] = None) -> None:
+                 ml_threshold: Optional[Tuple[float, ThresholdPreset]] = None,
+                 find_by_ext: bool = False) -> None:
         """Initialize Advanced credential scanner.
 
         Args:
@@ -61,12 +64,15 @@ class CredSweeper:
         config_dict["validation"]["ml_validation"] = ml_validation
         config_dict["validation"]["api_validation"] = api_validation
         config_dict["use_filters"] = use_filters
+        config_dict["find_by_ext"] = find_by_ext
+
         self.config = Config(config_dict)
         self.credential_manager = CredentialManager()
         self.scanner = Scanner(self.config, rule_path)
         self.json_filename: Optional[str] = json_filename
         self.ml_batch_size = ml_batch_size
         self.ml_threshold = ml_threshold
+        self.find_by_ext = find_by_ext
 
     def pool_initializer(self) -> None:
         """Ignore SIGINT in child processes."""
@@ -131,6 +137,22 @@ class CredSweeper:
         """
         # Get list credentials for each file
         logging.debug(f"Start scan file: {file_provider.file_path}")
+
+        if self.config.find_by_ext:
+            if FilePathExtractor.is_find_by_ext_file(self.config, file_provider.file_path):
+                candidate = Candidate(line_data_list=[
+                    LineData(self.config,
+                             line="dummy line",
+                             line_num=-1,
+                             path=file_provider.file_path,
+                             pattern=regex.compile(".*"))
+                ],
+                                      patterns=[regex.compile(".*")],
+                                      rule_name="Dummy candidate",
+                                      severity=Severity.INFO,
+                                      config=self.config)
+                return [candidate]
+
         try:
             scanContext = file_provider.get_analysis_target()
             return self.scanner.scan(scanContext)

--- a/credsweeper/config/config.py
+++ b/credsweeper/config/config.py
@@ -21,6 +21,7 @@ class Config:
         self.exclude_extensions: List[str] = config["exclude"]["extension"]
         self.source_extensions: List[str] = config["source_ext"]
         self.source_quote_ext: List[str] = config["source_quote_ext"]
+        self.find_by_ext_list: List[str] = config["find_by_ext_list"]
         self.check_for_literals: bool = config["check_for_literals"]
         self.not_allowed_path_pattern = regex.compile(f"{Util.get_regex_combine_or(self.NOT_ALLOWED_PATH)}",
                                                       flags=regex.IGNORECASE)
@@ -29,3 +30,4 @@ class Config:
         self.use_filters: bool = config["use_filters"]
         self.line_data_output: bool = config["line_data_output"]
         self.candidate_output: bool = config["candidate_output"]
+        self.find_by_ext: bool = config["find_by_ext"]

--- a/credsweeper/config/config_manager.py
+++ b/credsweeper/config/config_manager.py
@@ -5,16 +5,15 @@ import yaml
 
 from credsweeper.common.constants import DEFAULT_ENCODING
 
-CONFIG_PATH = Path(__file__).resolve().parent.parent.joinpath('secret')
+CONFIG_PATH = Path(__file__).resolve().parent.parent.joinpath("secret")
 
 
 class ConfigManager:
-
     @staticmethod
     def load_conf(conf_file):
         file_path = CONFIG_PATH.joinpath(conf_file)
         try:
-            with open(file_path, 'r', encoding=DEFAULT_ENCODING) as f:
+            with open(file_path, "r", encoding=DEFAULT_ENCODING) as f:
                 conf = yaml.load(f, Loader=yaml.FullLoader)
         except (IOError, OSError):
             logging.error(f"Failed to read {file_path}")

--- a/credsweeper/file_handler/file_path_extractor.py
+++ b/credsweeper/file_handler/file_path_extractor.py
@@ -47,7 +47,7 @@ class FilePathExtractor:
 
         for dirpath, _, filenames in os.walk(path):
             for filename in filenames:
-                file_path = f"{dirpath}/{filename}"
+                file_path = os.path.join(f"{dirpath}", f"{filename}")
                 if FilePathExtractor.check_exclude_file(config, file_path):
                     continue
                 if os.path.isfile(file_path):
@@ -88,6 +88,10 @@ class FilePathExtractor:
                 if new_parent == parent_directory:
                     return True
                 parent_directory = new_parent
+
+    @staticmethod
+    def is_find_by_ext_file(config: Config, path: str) -> bool:
+        return Util.get_extension(path) in config.find_by_ext_list
 
     @classmethod
     def check_exclude_file(cls, config: Config, path: str) -> bool:

--- a/credsweeper/secret/config.json
+++ b/credsweeper/secret/config.json
@@ -119,6 +119,17 @@
         ".h",
         ".hpp"
     ],
+    "find_by_ext_list": [
+        ".pem",
+        ".crt",
+        ".cer",
+        ".csr",
+        ".der",
+        ".pfx",
+        ".p12",
+        ".key",
+        ".jks"
+    ],
     "check_for_literals": true,
     "line_data_output": [
         "line",

--- a/credsweeper/validations/apply_validation.py
+++ b/credsweeper/validations/apply_validation.py
@@ -4,12 +4,10 @@ from typing import List
 from credsweeper.common.constants import KeyValidationOption
 from credsweeper.credentials import Candidate, CredentialManager
 from credsweeper.logger.logger import logging
-from credsweeper.validations.validation import Validation
 
 
 class ApplyValidation:
     """Class that allow parallel API validation using already declared pool."""
-
     def validate_credentials(self, pool: Pool, credential_manager: CredentialManager) -> None:
         old_cred: List[Candidate] = credential_manager.get_credentials()
         new_cred = []
@@ -30,13 +28,10 @@ class ApplyValidation:
         validation_option = KeyValidationOption.UNDECIDED
 
         if not cred.is_api_validation_available:
-            logging.debug(
-                f"No validation with external API available for current credential candidate: "
-                f"{cred.line_data_list[0].line}"
-            )
+            logging.debug(f"No validation with external API available for current credential candidate: "
+                          f"{cred.line_data_list[0].line}")
             return KeyValidationOption.NOT_AVAILABLE
 
-        validation: Validation
         for validation in cred.validations:
             current_api_validation: KeyValidationOption = validation.verify(cred.line_data_list)
             if current_api_validation is KeyValidationOption.VALIDATED_KEY:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,8 @@ def config() -> Config:
     config_dict["validation"]["ml_validation"] = False
     config_dict["validation"]["api_validation"] = False
     config_dict["use_filters"] = True
+    config_dict["find_by_ext"] = False
+    config_dict["find_by_ext_list"] = [".txt"]
     return Config(config_dict)
 
 

--- a/tests/file_handler/test_file_path_extractor.py
+++ b/tests/file_handler/test_file_path_extractor.py
@@ -1,4 +1,8 @@
+import pytest
+
+from credsweeper.config import Config
 from credsweeper.file_handler.file_path_extractor import FilePathExtractor
+from tests.conftest import config
 
 
 class TestFilePathExtractor:
@@ -19,3 +23,14 @@ class TestFilePathExtractor:
         filtered_files = FilePathExtractor.apply_gitignore(files)
 
         assert len(filtered_files) == 0
+
+    @pytest.mark.parametrize("file_path", ["/tmp/test.txt", "dummy.txt"])
+    def test_find_by_ext_file_p(self, config: Config, file_path: pytest.fixture) -> None:
+        config.find_by_ext = True
+        assert FilePathExtractor.is_find_by_ext_file(config, file_path)
+
+    @pytest.mark.parametrize("file_path", ["/tmp/test.bmp", "dummy.doc"])
+    def test_find_by_ext_file_n(self, config: Config, file_path: pytest.fixture) -> None:
+        assert not FilePathExtractor.is_find_by_ext_file(config, file_path)
+        config.find_by_ext = False
+        assert not FilePathExtractor.is_find_by_ext_file(config, file_path)

--- a/tests/test_utils/dummy_line_data.py
+++ b/tests/test_utils/dummy_line_data.py
@@ -17,6 +17,7 @@ def config() -> Config:
     config_dict["validation"]["ml_validation"] = False
     config_dict["validation"]["api_validation"] = False
     config_dict["use_filters"] = True
+    config_dict["find_by_ext"] = False
     return Config(config_dict)
 
 def get_line_data(file_path: str = "", line: str = "", pattern: str = r".*$", config: Config = config()) -> LineData:


### PR DESCRIPTION
Add `--find-by-ext` option for key files ( `.pem` , `.crt`, `.cer`,  `.csr`,  `.der`,  `.pfx`,  `.p12`, `.key` and `.jks`). #94 
By default, `--find-by-ext` option is `False`.

It just finding key files by extensions, so there is no `line_data`, `line_num` and so on.
Here is example.
``` json
[
    {
        "api_validation": "NOT_AVAILABLE",
        "ml_validation": "NOT_AVAILABLE",
        "line_data_list": [
            {
                "line": "dummy line",
                "line_num": -1,
                "path": "key_test/my_key.pem",
                "value": null,
                "variable": null,
                "entropy_validation": false
            }
        ],
        "ml_probability": null,
        "rule": "Dummy candidate",
        "severity": "info"
    }
]
```