### PR TITLE
Fix JSON Web Token regex to reduce FN cases

### DIFF
--- a/credsweeper/rules/config.yaml
+++ b/credsweeper/rules/config.yaml
@@ -161,12 +161,12 @@
   severity: medium
   type: pattern
   values:
-  - (?P<value>eyJ[A-Za-z0-9-_=]+\.eyJ[A-Za-z0-9-_=]+(\.[A-Za-z0-9-_.+\/=]+)?)
+  - (?P<value>eyJ[A-Za-z0-9-_=]+(\.[A-Za-z0-9-_.+\/=]+)?)
   filter_type: GeneralPattern
   use_ml: true
   validations: []
   required_substrings:
-    - .eyJ
+    - eyJ
   min_line_len: 9
 
 - name: MailChimp API Key


### PR DESCRIPTION
There were not many JWT cases in perfect form.
So I fixed `JSON Web Token` regex by remove `.eyj` string set and here is result.

I tested with [CredData](https://github.com/Samsung/CredData).

Before:
``` bash
result_cnt : 3981, lost_cnt : 0, true_cnt : 3662, false_cnt : 319
credsweeper -> TP : 3662, FP : 319, TN : 19454380, FN : 921, FPR : 0.0000163971, FNR : 0.2009600698, ACC : 0.9999362772, PRC : 0.9198693796, RCL : 0.7990399302, F1 : 0.8552078468
credsweeper Private Key -> TP : 953, FP : 0, TN : 4, FN : 39, FPR : 0E-10, FNR : 0.0393145161, ACC : 0.9608433735, PRC : 1.0000000000, RCL : 0.9606854839, F1 : 0.9799485861
credsweeper Predefined Pattern -> TP : 273, FP : 2, TN : 40, FN : 54, FPR : 0.0476190476, FNR : 0.1651376147, ACC : 0.8482384824, PRC : 0.9927272727, RCL : 0.8348623853, F1 : 0.9069767442
credsweeper Generic Token -> TP : 281, FP : 5, TN : 598, FN : 52, FPR : 0.0082918740, FNR : 0.1561561562, ACC : 0.9391025641, PRC : 0.9825174825, RCL : 0.8438438438, F1 : 0.9079159935
credsweeper Generic Secret -> TP : 975, FP : 4, TN : 214, FN : 81, FPR : 0.0183486239, FNR : 0.0767045455, ACC : 0.9332810047, PRC : 0.9959141982, RCL : 0.9232954545, F1 : 0.9582309582
credsweeper Password -> TP : 986, FP : 129, TN : 4167, FN : 409, FPR : 0.0300279330, FNR : 0.2931899642, ACC : 0.9054647689, PRC : 0.8843049327, RCL : 0.7068100358, F1 : 0.7856573705
credsweeper Other -> TP : 113, FP : 3, TN : 742, FN : 261, FPR : 0.0040268456, FNR : 0.6978609626, ACC : 0.7640750670, PRC : 0.9741379310, RCL : 0.3021390374, F1 : 0.4612244898
credsweeper Seed, Salt, Nonce -> TP : 33, FP : 0, TN : 8, FN : 6, FPR : 0E-10, FNR : 0.1538461538, ACC : 0.8723404255, PRC : 1.0000000000, RCL : 0.8461538462, F1 : 0.9166666667
credsweeper Authentication Key & Token -> TP : 48, FP : 1, TN : 31, FN : 19, FPR : 0.0312500000, FNR : 0.2835820896, ACC : 0.7979797980, PRC : 0.9795918367, RCL : 0.7164179104, F1 : 0.8275862069
```

After:
``` bash
result_cnt : 4103, lost_cnt : 65, true_cnt : 3701, false_cnt : 337
credsweeper -> TP : 3701, FP : 337, TN : 19454362, FN : 882, FPR : 0.0000173223, FNR : 0.1924503600, ACC : 0.9999373564, PRC : 0.9165428430, RCL : 0.8075496400, F1 : 0.8586010904
credsweeper Private Key -> TP : 953, FP : 0, TN : 4, FN : 39, FPR : 0E-10, FNR : 0.0393145161, ACC : 0.9608433735, PRC : 1.0000000000, RCL : 0.9606854839, F1 : 0.9799485861
credsweeper Predefined Pattern -> TP : 310, FP : 3, TN : 39, FN : 17, FPR : 0.0714285714, FNR : 0.0519877676, ACC : 0.9457994580, PRC : 0.9904153355, RCL : 0.9480122324, F1 : 0.9687500000
credsweeper Generic Token -> TP : 281, FP : 5, TN : 598, FN : 52, FPR : 0.0082918740, FNR : 0.1561561562, ACC : 0.9391025641, PRC : 0.9825174825, RCL : 0.8438438438, F1 : 0.9079159935
credsweeper Generic Secret -> TP : 975, FP : 4, TN : 214, FN : 81, FPR : 0.0183486239, FNR : 0.0767045455, ACC : 0.9332810047, PRC : 0.9959141982, RCL : 0.9232954545, F1 : 0.9582309582
credsweeper Password -> TP : 986, FP : 129, TN : 4167, FN : 409, FPR : 0.0300279330, FNR : 0.2931899642, ACC : 0.9054647689, PRC : 0.8843049327, RCL : 0.7068100358, F1 : 0.7856573705
credsweeper Other -> TP : 115, FP : 3, TN : 742, FN : 259, FPR : 0.0040268456, FNR : 0.6925133690, ACC : 0.7658623771, PRC : 0.9745762712, RCL : 0.3074866310, F1 : 0.4674796748
credsweeper Seed, Salt, Nonce -> TP : 33, FP : 0, TN : 8, FN : 6, FPR : 0E-10, FNR : 0.1538461538, ACC : 0.8723404255, PRC : 1.0000000000, RCL : 0.8461538462, F1 : 0.9166666667
credsweeper Authentication Key & Token -> TP : 48, FP : 1, TN : 31, FN : 19, FPR : 0.0312500000, FNR : 0.2835820896, ACC : 0.7979797980, PRC : 0.9795918367, RCL : 0.7164179104, F1 : 0.8275862069
```

It can be seen that the value of recall of `Predefined Pattern` has increased considerably, and its F1 score has also increased a lot accordingly.