### PR TITLE
Banner with version and CRC32 sum of program files

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -125,6 +125,6 @@ jobs:
 
     - name: Verify benchmark scores of the PR
       # update cicd/benchmark.txt with uploaded artifact if a difference is found
-      run: LC_ALL=C sort CredSweeper/cicd/benchmark.txt | diff benchmark.txt -
+      run: LC_ALL=C sort CredSweeper/cicd/benchmark.txt | diff - benchmark.txt
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -183,7 +183,7 @@ jobs:
 
     - name: Banner and version check
       run: |
-        apt install libarchive-zip-perl
+        sudo apt install libarchive-zip-perl
         crc32_int=0
         for f in $(find credsweeper -iregex '.*\.\(py\|json\|yaml\|txt\|onnx\)$'); do
             file_crc32_hex=$(crc32 $f)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -181,7 +181,7 @@ jobs:
 
     # # # Banner crc32
 
-    - name: Integrity and version check
+    - name: Banner and version check
       run: |
         crc32_int=0
         for f in $(find credsweeper -iregex '.*\.\(py\|json\|yaml\|txt\|onnx\)$'); do

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,10 @@ jobs:
 
     steps:
 
+    # # # For banner check
+    - name: Setup crc32 tool
+      run: sudo apt-get update && sudo apt-get install libarchive-zip-perl && crc32 /etc/fstab
+
     # # # MUST be full history to check git workflow
 
     - name: Checkout
@@ -183,7 +187,6 @@ jobs:
 
     - name: Banner and version check
       run: |
-        sudo apt install libarchive-zip-perl
         crc32_int=0
         for f in $(find credsweeper -iregex '.*\.\(py\|json\|yaml\|txt\|onnx\)$'); do
             file_crc32_hex=$(crc32 $f)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -183,6 +183,7 @@ jobs:
 
     - name: Banner and version check
       run: |
+        apt install libarchive-zip-perl
         crc32_int=0
         for f in $(find credsweeper -iregex '.*\.\(py\|json\|yaml\|txt\|onnx\)$'); do
             file_crc32_hex=$(crc32 $f)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -193,8 +193,10 @@ jobs:
             crc32_int=$(( ${crc32_int} ^ ${file_crc32_int} ))
             done
         version_with_crc="$(credsweeper --version | head -1) crc32:$(printf '%x' ${crc32_int})"
+        echo "version_with_crc = '${version_with_crc}'"
         banner=$(credsweeper --banner --path requirements.txt | head -1)
-        if [ -z "${version_with_crc}" ] || [ -z "${banner}"] || [ "${version_with_crc}" != "${banner}" ]; then
+        echo "banner = '${banner}'"
+        if ! [ -n "${version_with_crc}" ] && [ -n "${banner}" ] && [ "${version_with_crc}" == "${banner}" ]; then
             echo "'${version_with_crc}' != '${banner}'"
             exit 1
         fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -179,4 +179,22 @@ jobs:
         name: flake8_report
         path: flake8.txt
 
+    # # # Banner crc32
+
+    - name: Integrity and version check
+      run: |
+        crc32_int=0
+        for f in $(find credsweeper -iregex '.*\.\(py\|json\|yaml\|txt\|onnx\)$'); do
+            file_crc32_hex=$(crc32 $f)
+            file_crc32_int=$((16#${file_crc32_hex}))
+            crc32_int=$(( ${crc32_int} ^ ${file_crc32_int} ))
+            done
+
+        version_with_crc="$(credsweeper --version | head -1) crc32:$(printf '%x' ${crc32_int})"
+        banner=$(credsweeper --banner --path requirement.txt | head -1)
+        if [ -z "${version_with_crc}" ] || [ -z "${banner}"] || [ "${version_with_crc}" != "${banner}" ]; then
+            echo "'${version_with_crc}' != '${banner}'"
+            exit 1
+        fi
+
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,10 +18,6 @@ jobs:
 
     steps:
 
-    # # # For banner check
-    - name: Setup crc32 tool
-      run: sudo apt-get update && sudo apt-get install libarchive-zip-perl && crc32 /etc/fstab
-
     # # # MUST be full history to check git workflow
 
     - name: Checkout
@@ -185,6 +181,9 @@ jobs:
 
     # # # Banner crc32
 
+    - name: Setup crc32 tool
+      run: sudo apt-get update && sudo apt-get install libarchive-zip-perl && crc32 /etc/fstab
+
     - name: Banner and version check
       run: |
         crc32_int=0
@@ -193,9 +192,8 @@ jobs:
             file_crc32_int=$((16#${file_crc32_hex}))
             crc32_int=$(( ${crc32_int} ^ ${file_crc32_int} ))
             done
-
         version_with_crc="$(credsweeper --version | head -1) crc32:$(printf '%x' ${crc32_int})"
-        banner=$(credsweeper --banner --path requirement.txt | head -1)
+        banner=$(credsweeper --banner --path requirements.txt | head -1)
         if [ -z "${version_with_crc}" ] || [ -z "${banner}"] || [ "${version_with_crc}" != "${banner}" ]; then
             echo "'${version_with_crc}' != '${banner}'"
             exit 1

--- a/credsweeper/__init__.py
+++ b/credsweeper/__init__.py
@@ -1,5 +1,3 @@
-import os
-
 from credsweeper.app import CredSweeper
 from credsweeper.common.constants import ThresholdPreset
 from credsweeper.file_handler import ContentProvider, ByteContentProvider, DiffContentProvider, StringContentProvider, \
@@ -7,8 +5,6 @@ from credsweeper.file_handler import ContentProvider, ByteContentProvider, DiffC
     TextContentProvider
 from credsweeper.ml_model.ml_validator import MlValidator
 from credsweeper.validations.apply_validation import ApplyValidation
-
-os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
 
 __all__ = [
     'ApplyValidation',  #

--- a/credsweeper/__main__.py
+++ b/credsweeper/__main__.py
@@ -4,7 +4,6 @@ import os
 import sys
 import time
 from argparse import ArgumentParser, ArgumentTypeError, Namespace
-from pathlib import Path
 from typing import Any, Union, Optional, Dict
 
 from credsweeper import __version__
@@ -74,7 +73,7 @@ def check_integrity() -> int:
     Returns CRC32 of files in integer
     """
     crc32 = 0
-    for root, dirs, files in os.walk(Path(__file__).resolve().parent):
+    for root, dirs, files in os.walk(os.path.dirname(os.path.realpath(__file__))):
         for file_path in files:
             if Util.get_extension(file_path) in [".py", ".json", ".txt", ".yaml", ".onnx"]:
                 with open(os.path.join(root, file_path), "rb") as f:

--- a/credsweeper/__main__.py
+++ b/credsweeper/__main__.py
@@ -252,7 +252,7 @@ def main() -> int:
     start_time = time.time()
     args = get_arguments()
     if args.banner:
-        print(f"CredSweeper v{__version__} crc32:{check_integrity():08x}")
+        print(f"CredSweeper {__version__} crc32:{check_integrity():08x}")
     Logger.init_logging(args.log)
     logger.info(f"Init CredSweeper object with arguments: {args}")
     summary: Dict[str, int] = {}

--- a/credsweeper/__main__.py
+++ b/credsweeper/__main__.py
@@ -124,9 +124,9 @@ def get_arguments() -> Namespace:
                         metavar="POSITIVE_INT")
     parser.add_argument("--ml_threshold",
                         help="setup threshold for the ml model. "
-                             "The lower the threshold - the more credentials will be reported. "
-                             f"Allowed values: float between 0 and 1, or any of {[e.value for e in ThresholdPreset]} "
-                             "(default: medium)",
+                        "The lower the threshold - the more credentials will be reported. "
+                        f"Allowed values: float between 0 and 1, or any of {[e.value for e in ThresholdPreset]} "
+                        "(default: medium)",
                         type=threshold_or_float,
                         default=ThresholdPreset.medium,
                         dest="ml_threshold",
@@ -142,7 +142,7 @@ def get_arguments() -> Namespace:
                         metavar="POSITIVE_INT")
     parser.add_argument("--api_validation",
                         help="add credential api validation option to credsweeper pipeline. "
-                             "External API is used to reduce FP for some rule types.",
+                        "External API is used to reduce FP for some rule types.",
                         dest="api_validation",
                         action="store_true")
     parser.add_argument("--jobs",

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -15,7 +15,7 @@ Get all argument list:
 
     usage: python -m credsweeper [-h] (--path PATH [PATH ...] | --diff_path PATH [PATH ...] | --export_config [PATH]) [--rules [PATH]] [--config [PATH]] [--denylist PATH] [--find-by-ext]
                                  [--depth POSITIVE_INT] [--ml_threshold FLOAT_OR_STR] [--ml_batch_size POSITIVE_INT] [--api_validation] [--jobs POSITIVE_INT] [--skip_ignored]
-                                 [--save-json [PATH]] [--save-xlsx [PATH]] [--log LOG_LEVEL] [--size_limit SIZE_LIMIT] [--version]
+                                 [--save-json [PATH]] [--save-xlsx [PATH]] [--log LOG_LEVEL] [--size_limit SIZE_LIMIT] [--banner] [--version]
     optional arguments:
       -h, --help            show this help message and exit
       --path PATH [PATH ...]
@@ -44,6 +44,7 @@ Get all argument list:
                             provide logging level. Example --log debug, (default: 'warning')
       --size_limit SIZE_LIMIT
                             set size limit of files that for scanning (eg. 1GB / 10MiB / 1000)
+      --banner              show version and crc32 sum of CredSweeper files at start
       --version, -V         show program's version number and exit
 
 

--- a/fuzz/fuzzing.sh
+++ b/fuzz/fuzzing.sh
@@ -13,11 +13,13 @@ export DO_ATHERIS_INSTRUMENT=1
 
 # make seed from CRC32 of source files to keep the same sequence
 seed=0
-for f in $(find credsweeper -wholename "*.py"); do
+for f in $(find credsweeper -iregex '.*\.\(py\|json\|yaml\|txt\|onnx\)$'); do
     file_crc32_hex=$(crc32 $f)
     file_crc32_int=$((16#${file_crc32_hex}))
     seed=$(( ${seed} ^ ${file_crc32_int} ))
     done
+
+printf 'CRC32: %x\n' $seed
 
 python -m fuzz \
     -rss_limit_mb=6500 \

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -287,7 +287,7 @@ class TestApp(TestCase):
             json_filename = os.path.join(tmp_dir, f"{__name__}.json")
             _stdout, _stderr = self._m_credsweeper(["--banner", "--export_config", json_filename])
             output = " ".join(_stdout.decode().split())
-            self.assertRegex(output, r"CredSweeper v\d+\.\d+\.\d+ crc32:[0-9a-f]{8}")
+            self.assertRegex(output, r"CredSweeper \d+\.\d+\.\d+ crc32:[0-9a-f]{8}")
 
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -199,6 +199,7 @@ class TestApp(TestCase):
                    " [--save-xlsx [PATH]]" \
                    " [--log LOG_LEVEL]" \
                    " [--size_limit SIZE_LIMIT]" \
+                   " [--banner] " \
                    " [--version] " \
                    "python -m credsweeper: error: one of the arguments" \
                    " --path" \
@@ -282,9 +283,11 @@ class TestApp(TestCase):
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
     def test_banner_p(self) -> None:
-        _stdout, _stderr = self._m_credsweeper(["--banner"])
-        output = " ".join(_stdout.decode().split())
-        self.assertRegex(output, r"CredSweeper v\d+\.\d+\.\d+ crc32:[0-9a-f]{8}")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            json_filename = os.path.join(tmp_dir, f"{__name__}.json")
+            _stdout, _stderr = self._m_credsweeper(["--banner", "--export_config", json_filename])
+            output = " ".join(_stdout.decode().split())
+            self.assertRegex(output, r"CredSweeper v\d+\.\d+\.\d+ crc32:[0-9a-f]{8}")
 
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -274,12 +274,17 @@ class TestApp(TestCase):
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
     def test_version_p(self) -> None:
-        _stdout, stderr = self._m_credsweeper(["--version"])
-
+        _stdout, _stderr = self._m_credsweeper(["--version"])
         # Merge more than two whitespaces into one because _stdout and _stderr are changed based on the terminal size
         output = " ".join(_stdout.decode("UTF-8").split())
+        self.assertRegex(output, r"CredSweeper \d+\.\d+\.\d+")
 
-        assert re.match(r"CredSweeper \d+\.\d+\.\d+", output)
+    # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+    def test_banner_p(self) -> None:
+        _stdout, _stderr = self._m_credsweeper(["--banner"])
+        output = " ".join(_stdout.decode().split())
+        self.assertRegex(output, r"CredSweeper v\d+\.\d+\.\d+ crc32:[0-9a-f]{8}")
 
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 


### PR DESCRIPTION
## Description

- Added `--banner` option to distinguish various version in development. CRC32 sum of files might be displayed in banner at program start. ```CredSweeper v1.4.2 crc32:ae1baf99```. It is not an integrity check but fast.
- Use natural order in benchmark first:old, second:new.

## How has this been tested?

- [x] Add `--banner` to arguments. See crc32 value. 
- [x] Check action 'Static analysis and code style' step 'Integrity and version check'
