### PR TITLE
Limit sphinx-autodoc-typehints<1.19.3

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 m2r2
 sphinx_rtd_theme
-sphinx-autodoc-typehints
+sphinx-autodoc-typehints<1.19.3
 autodocsumm


### PR DESCRIPTION
to avoid bug
the same: https://github.com/tox-dev/sphinx-autodoc-typehints/issues/259

this blocks fail:
https://github.com/Samsung/CredSweeper/blob/765c58aff190301546e3a3c908faea1f7c81aaa7/credsweeper/scanner/scan_type/pem_key_pattern.py#L111
https://github.com/Samsung/CredSweeper/blob/765c58aff190301546e3a3c908faea1f7c81aaa7/credsweeper/scanner/scan_type/pem_key_pattern.py#L84

## Description

- Fix publish step with limited version of sphinx-autodoc-typehints

## How has this been tested?

- [x] Publish workflow must passed
