### PR TITLE
Added Info field to json report

### DIFF
--- a/credsweeper/credentials/candidate.py
+++ b/credsweeper/credentials/candidate.py
@@ -147,12 +147,13 @@ class Candidate:
         full_output = {
             "api_validation": self.api_validation.name,
             "ml_validation": self.ml_validation.name,
-            "line_data_list": [line_data.to_json() for line_data in self.line_data_list],
             "patterns": [pattern.pattern for pattern in self.patterns],
             "ml_probability": self.ml_probability,
             "rule": self.rule_name,
             "severity": self.severity.value,
             "use_ml": self.use_ml,
+            # put the array to end to make json more readable
+            "line_data_list": [line_data.to_json() for line_data in self.line_data_list],
         }
         if self.config is not None:
             reported_output = {k: v for k, v in full_output.items() if k in self.config.candidate_output}
@@ -188,6 +189,7 @@ class Candidate:
                     line="dummy line",  #
                     line_num=-1,  #
                     path=file_path,  #
+                    info="dummy info",  #
                     pattern=regex.compile(".*"))
             ],
             patterns=[regex.compile(".*")],  #

--- a/credsweeper/credentials/line_data.py
+++ b/credsweeper/credentials/line_data.py
@@ -14,6 +14,7 @@ class LineData:
         line: string variable, line
         line_num: int variable, number of line in file
         path: string variable, path to file
+        info: extended info which way the data was found
         pattern: regex pattern, detected pattern in line
         separator: optional string variable, separators between variable and value
         separator_span: optional tuple variable, separator position
@@ -25,12 +26,13 @@ class LineData:
     comment_starts = ["//", "*", "#", "/*", "<!––", "%{", "%", "...", "(*", "--", "--[[", "#="]
     bash_param_split = regex.compile("\\s+(\\-|\\||\\>|\\w+?\\>|\\&)")
 
-    def __init__(self, config: Config, line: str, line_num: int, path: str, pattern: regex.Pattern) -> None:
+    def __init__(self, config: Config, line: str, line_num: int, path: str, info: str, pattern: regex.Pattern) -> None:
         self.config = config
         self.key: Optional[str] = None
         self.line: str = line
         self.line_num: int = line_num
         self.path: str = path
+        self.info: str = info
         self.pattern: regex.Pattern = pattern
         self.separator: Optional[str] = None
         self.separator_span: Optional[Tuple[int, int]] = None
@@ -80,6 +82,16 @@ class LineData:
     def path(self, path: str) -> None:
         """path setter"""
         self.__path = path
+
+    @property
+    def info(self) -> str:
+        """info getter"""
+        return self.__info
+
+    @info.setter
+    def info(self, info: str) -> None:
+        """info setter"""
+        self.__info = info
 
     @property
     def pattern(self) -> regex.Pattern:
@@ -270,6 +282,7 @@ class LineData:
             "line": self.line,
             "line_num": self.line_num,
             "path": self.path,
+            "info": self.info,
             "pattern": self.pattern.pattern,
             "separator": self.separator,
             "separator_span": self.separator_span,

--- a/credsweeper/credentials/line_data.py
+++ b/credsweeper/credentials/line_data.py
@@ -14,7 +14,7 @@ class LineData:
         line: string variable, line
         line_num: int variable, number of line in file
         path: string variable, path to file
-        info: extended info which way the data was found
+        info: additional info about how the data was detected
         pattern: regex pattern, detected pattern in line
         separator: optional string variable, separators between variable and value
         separator_span: optional tuple variable, separator position

--- a/credsweeper/file_handler/analysis_target.py
+++ b/credsweeper/file_handler/analysis_target.py
@@ -8,3 +8,4 @@ class AnalysisTarget:
     line_num: int
     lines: List[str]
     file_path: str
+    info: str

--- a/credsweeper/file_handler/byte_content_provider.py
+++ b/credsweeper/file_handler/byte_content_provider.py
@@ -15,8 +15,8 @@ class ByteContentProvider(ContentProvider):
 
     """
 
-    def __init__(self, content: bytes, file_path: Optional[str] = None) -> None:
-        super().__init__(file_path if file_path is not None else "")
+    def __init__(self, content: bytes, file_path: Optional[str] = None, info: Optional[str] = None) -> None:
+        super().__init__(file_path, info)
         self.lines = Util.decode_bytes(content)
 
     def get_analysis_target(self) -> List[AnalysisTarget]:

--- a/credsweeper/file_handler/content_provider.py
+++ b/credsweeper/file_handler/content_provider.py
@@ -7,8 +7,9 @@ from credsweeper.file_handler.analysis_target import AnalysisTarget
 class ContentProvider(ABC):
     """Base class to provide access to analysis targets for scanned object."""
 
-    def __init__(self, _file_path: str) -> None:
-        self.__file_path = _file_path
+    def __init__(self, file_path: Optional[str] = None, info: Optional[str] = None) -> None:
+        self.file_path: str = file_path
+        self.info: str = info
 
     @abstractmethod
     def get_analysis_target(self) -> List[AnalysisTarget]:
@@ -25,15 +26,30 @@ class ContentProvider(ABC):
         """file_path getter"""
         return self.__file_path
 
+    @file_path.setter
+    def file_path(self, _file_path: str) -> None:
+        """file_path setter"""
+        self.__file_path = _file_path if _file_path else ""
+
+    @property
+    def info(self) -> str:
+        """info getter"""
+        return self.__info
+
+    @info.setter
+    def info(self, _info: str) -> None:
+        """info getter"""
+        self.__info = _info if _info else ""
+
     def lines_to_targets(self, lines: List[str], line_nums: Optional[List[int]] = None) -> List[AnalysisTarget]:
         """Creates list of targets with multiline concatenation"""
         targets = []
         if line_nums:
             for line, line_num in zip(lines, line_nums):
-                target = AnalysisTarget(line, line_num, lines, self.file_path)
+                target = AnalysisTarget(line, line_num, lines, self.file_path, self.info)
                 targets.append(target)
         else:
             for i, line in enumerate(lines):
-                target = AnalysisTarget(line, i + 1, lines, self.file_path)
+                target = AnalysisTarget(line, i + 1, lines, self.file_path, self.info)
                 targets.append(target)
         return targets

--- a/credsweeper/file_handler/data_content_provider.py
+++ b/credsweeper/file_handler/data_content_provider.py
@@ -13,8 +13,8 @@ class DataContentProvider(ContentProvider):
 
     """
 
-    def __init__(self, data: bytes, file_path: Optional[str] = None) -> None:
-        super().__init__(file_path if file_path is not None else "")
+    def __init__(self, data: bytes, file_path: Optional[str] = None, info: Optional[str] = None) -> None:
+        super().__init__(file_path, info)
         self.data = data
 
     @property

--- a/credsweeper/file_handler/diff_content_provider.py
+++ b/credsweeper/file_handler/diff_content_provider.py
@@ -60,4 +60,7 @@ class DiffContentProvider(ContentProvider):
         """
         lines_data = Util.preprocess_file_diff(self.diff)
         change_numbs, all_lines = self.parse_lines_data(lines_data)
-        return [AnalysisTarget(all_lines[l_numb - 1], l_numb, all_lines, self.file_path) for l_numb in change_numbs]
+        return [
+            AnalysisTarget(all_lines[l_numb - 1], l_numb, all_lines, self.file_path, self.change_type)
+            for l_numb in change_numbs
+        ]

--- a/credsweeper/file_handler/string_content_provider.py
+++ b/credsweeper/file_handler/string_content_provider.py
@@ -13,8 +13,8 @@ class StringContentProvider(ContentProvider):
 
     """
 
-    def __init__(self, lines: List[str], file_path: Optional[str] = None) -> None:
-        super().__init__(file_path if file_path is not None else "")
+    def __init__(self, lines: List[str], file_path: Optional[str] = None, info: Optional[str] = None) -> None:
+        super().__init__(file_path, info)
         self.lines = lines
 
     def get_analysis_target(self) -> List[AnalysisTarget]:
@@ -24,4 +24,4 @@ class StringContentProvider(ContentProvider):
             list of analysis targets based on every row in file
 
         """
-        return [AnalysisTarget(line, i + 1, self.lines, self.file_path) for i, line in enumerate(self.lines)]
+        return [AnalysisTarget(line, i + 1, self.lines, self.file_path, self.info) for i, line in enumerate(self.lines)]

--- a/credsweeper/file_handler/text_content_provider.py
+++ b/credsweeper/file_handler/text_content_provider.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from credsweeper.file_handler.analysis_target import AnalysisTarget
 from credsweeper.file_handler.content_provider import ContentProvider
@@ -16,7 +16,7 @@ class TextContentProvider(ContentProvider):
 
     """
 
-    def __init__(self, file_path: str, change_type: Optional[str] = None, diff: Optional[List[Dict]] = None) -> None:
+    def __init__(self, file_path: str) -> None:
         super().__init__(file_path)
 
     def get_analysis_target(self) -> List[AnalysisTarget]:

--- a/credsweeper/scanner/scan_type/multi_pattern.py
+++ b/credsweeper/scanner/scan_type/multi_pattern.py
@@ -76,8 +76,13 @@ class MultiPattern(ScanType):
         candi_line_num = candidate.line_data_list[0].line_num + line_num_margin
         candi_line = target.lines[candi_line_num - 1]
 
-        line_data = cls.get_line_data(config, candi_line, candi_line_num, target.file_path, rule.patterns[1],
-                                      rule.filters)
+        line_data = cls.get_line_data(config=config,
+                                      line=candi_line,
+                                      line_num=candi_line_num,
+                                      file_path=target.file_path,
+                                      info=target.info,
+                                      pattern=rule.patterns[1],
+                                      filters=rule.filters)
 
         if line_data is None:
             return False

--- a/credsweeper/scanner/scan_type/scan_type.py
+++ b/credsweeper/scanner/scan_type/scan_type.py
@@ -64,7 +64,7 @@ class ScanType(ABC):
         return False
 
     @classmethod
-    def get_line_data(cls, config: Config, line: str, line_num: int, file_path: str, pattern: regex.Pattern,
+    def get_line_data(cls, config: Config, line: str, line_num: int, file_path: str, info: str, pattern: regex.Pattern,
                       filters: List[Filter]) -> Optional[LineData]:
         """Check if regex pattern is present in line, and line should not be removed by filters.
 
@@ -73,6 +73,7 @@ class ScanType(ABC):
             line: Line to check
             line_num: Line number of a current line
             file_path: Path to the file that contain current line
+            info: Extended info
             pattern: Compiled regex object to be searched in line
             filters: Filters to use
 
@@ -83,7 +84,7 @@ class ScanType(ABC):
         if not cls.is_valid_line(line, pattern, line_num, file_path):
             return None
         logger.debug("Valid line for pattern: %s in file: %s:%d in line: %s", pattern, file_path, line_num, line)
-        line_data = LineData(config, line, line_num, file_path, pattern)
+        line_data = LineData(config=config, line=line, line_num=line_num, path=file_path, info=info, pattern=pattern)
 
         if cls.filtering(config, line_data, filters):
             return None
@@ -157,8 +158,13 @@ class ScanType(ABC):
         if len(config.exclude_lines) > 0 and target.line.strip() in config.exclude_lines:
             return None
 
-        line_data = cls.get_line_data(config, target.line, target.line_num, target.file_path, rule.patterns[0],
-                                      rule.filters)
+        line_data = cls.get_line_data(config=config,
+                                      line=target.line,
+                                      line_num=target.line_num,
+                                      file_path=target.file_path,
+                                      info=target.info,
+                                      pattern=rule.patterns[0],
+                                      filters=rule.filters)
 
         if line_data is None:
             return None

--- a/credsweeper/secret/config.json
+++ b/credsweeper/secret/config.json
@@ -2,7 +2,10 @@
     "exclude": {
         "pattern": [],
         "containers": [
+            ".apk",
+            ".docx",
             ".gz",
+            ".xlsx",
             ".zip"
         ],
         "extension": [
@@ -15,7 +18,6 @@
             ".class",
             ".css",
             ".dmg",
-            ".docx",
             ".ear",
             ".eot",
             ".exe",
@@ -60,7 +62,6 @@
             ".webp",
             ".woff",
             ".xls",
-            ".xlsx",
             ".yuv"
         ],
         "path": [
@@ -138,6 +139,7 @@
         "line",
         "line_num",
         "path",
+        "info",
         "value",
         "variable",
         "entropy_validation"
@@ -145,9 +147,9 @@
     "candidate_output": [
         "rule",
         "severity",
-        "line_data_list",
         "api_validation",
         "ml_validation",
-        "ml_probability"
+        "ml_probability",
+        "line_data_list"
     ]
 }

--- a/tests/common/test_constants.py
+++ b/tests/common/test_constants.py
@@ -10,7 +10,7 @@ class TestConstants:
     @pytest.mark.parametrize("line", ["melon = 'banAna'", "melon : 'banAna'", "melon := 'banAna'"])
     def test_separator_common_p(self, config: Config, file_path: pytest.fixture, line: str) -> None:
         pattern = Util.get_keyword_pattern("melon")
-        line_data = LineData(config, line, 1, file_path, pattern)
+        line_data = LineData(config, line, 1, file_path, info='dummy', pattern=pattern)
         assert line_data.value == "banAna"
 
     @pytest.mark.parametrize("line, value",
@@ -20,5 +20,5 @@ class TestConstants:
                               ["'password': 'ENC[lqjdoxlandicpfpqk]'", "ENC[lqjdoxlandicpfpqk]"]])
     def test_keyword_pattern_common_p(self, config: Config, file_path: pytest.fixture, line: str, value: str) -> None:
         pattern = Util.get_keyword_pattern("password")
-        line_data = LineData(config, line, 1, file_path, pattern)
+        line_data = LineData(config, line, 1, file_path, info='dummy', pattern=pattern)
         assert line_data.value == value

--- a/tests/common/test_constants.py
+++ b/tests/common/test_constants.py
@@ -10,7 +10,7 @@ class TestConstants:
     @pytest.mark.parametrize("line", ["melon = 'banAna'", "melon : 'banAna'", "melon := 'banAna'"])
     def test_separator_common_p(self, config: Config, file_path: pytest.fixture, line: str) -> None:
         pattern = Util.get_keyword_pattern("melon")
-        line_data = LineData(config, line, 1, file_path, info='dummy', pattern=pattern)
+        line_data = LineData(config, line, 1, file_path, info="dummy", pattern=pattern)
         assert line_data.value == "banAna"
 
     @pytest.mark.parametrize("line, value",
@@ -20,5 +20,5 @@ class TestConstants:
                               ["'password': 'ENC[lqjdoxlandicpfpqk]'", "ENC[lqjdoxlandicpfpqk]"]])
     def test_keyword_pattern_common_p(self, config: Config, file_path: pytest.fixture, line: str, value: str) -> None:
         pattern = Util.get_keyword_pattern("password")
-        line_data = LineData(config, line, 1, file_path, info='dummy', pattern=pattern)
+        line_data = LineData(config, line, 1, file_path, info="dummy", pattern=pattern)
         assert line_data.value == value

--- a/tests/credentials/test_credential_manager.py
+++ b/tests/credentials/test_credential_manager.py
@@ -10,7 +10,7 @@ class TestCredentialManager:
         "line", ["apiKeyToken = 'mybstscrt'", "SecretToken = 'mybstscrt'", "secret = AKIAGIREOGIAWSKEY123"])
     def test_groups_p(self, line):
         cred_sweeper = CredSweeper()
-        targets = [AnalysisTarget(line, i + 1, [line], "") for i, line in enumerate([line])]
+        targets = [AnalysisTarget(line, i + 1, [line], "", "") for i, line in enumerate([line])]
         detections = cred_sweeper.scanner.scan(targets)
         cred_sweeper.credential_manager.set_credentials(detections)
         groups = cred_sweeper.credential_manager.group_credentials()
@@ -23,7 +23,7 @@ class TestCredentialManager:
     ])
     def test_groups_n(self, line):
         cred_sweeper = CredSweeper()
-        targets = [AnalysisTarget(line, i + 1, [line], "") for i, line in enumerate([line])]
+        targets = [AnalysisTarget(line, i + 1, [line], "", "") for i, line in enumerate([line])]
         detections = cred_sweeper.scanner.scan(targets)
         cred_sweeper.credential_manager.set_credentials(detections)
         groups = cred_sweeper.credential_manager.group_credentials()

--- a/tests/credentials/test_line_data.py
+++ b/tests/credentials/test_line_data.py
@@ -20,7 +20,7 @@ class TestLineData:
         Rerun few times with different variable names to assure that different rules behave in a same way
         """
         formatted_line = line.format(var_name)
-        line_data = LineData(config, formatted_line, 0, file_path, rule.patterns[0])
+        line_data = LineData(config, formatted_line, 0, file_path, "test_info", rule.patterns[0])
         assert line_data.value == "ngh679x"
         assert line_data.variable == var_name
 
@@ -31,7 +31,7 @@ class TestLineData:
                            rule_name: str, config: Config) -> None:
         """Check that most simple case for credentials is parsed correctly"""
         formatted_line = line.format(var_name)
-        line_data = LineData(config, formatted_line, 0, file_path, rule.patterns[0])
+        line_data = LineData(config, formatted_line, 0, file_path, "test_info", rule.patterns[0])
         assert line_data.value == "ngh679x"
         assert line_data.variable == var_name
 
@@ -41,7 +41,7 @@ class TestLineData:
     def test_multiple_word_variable_name_p(self, file_path: pytest.fixture, rule: pytest.fixture, line: str,
                                            varname: str, rule_name: str, config: Config) -> None:
         """Check that if variable name contain spaces (like field in JSON) it would be parsed correctly"""
-        line_data = LineData(config, line, 0, file_path, rule.patterns[0])
+        line_data = LineData(config, line, 0, file_path, "test_info", rule.patterns[0])
         assert line_data.value == "ngh679x"
         assert line_data.variable == varname
 
@@ -53,7 +53,7 @@ class TestLineData:
                              rule_name: str, config: Config) -> None:
         """Check that secrets in function arguments parsed in a correct way (without argument name)"""
         formatted_line = line.format(var_name)
-        line_data = LineData(config, formatted_line, 0, file_path, rule.patterns[0])
+        line_data = LineData(config, formatted_line, 0, file_path, "test_info", rule.patterns[0])
         assert line_data.value == "ngh679x"
         assert line_data.variable == var_name
 
@@ -68,7 +68,7 @@ class TestLineData:
                                  rule_name: str, config: Config) -> None:
         """Check that secrets in function arguments parsed in a correct way (with argument name)"""
         formatted_line = line.format(var_name)
-        line_data = LineData(config, formatted_line, 0, file_path, rule.patterns[0])
+        line_data = LineData(config, formatted_line, 0, file_path, "test_info", rule.patterns[0])
         assert line_data.value == "ngh679x"
         assert line_data.variable == var_name
 
@@ -87,6 +87,6 @@ class TestLineData:
                              rule_name: str, config: Config) -> None:
         """Check credentials declared in CLI arguments"""
         formatted_line = line.format(var_name)
-        line_data = LineData(config, formatted_line, 0, file_path, rule.patterns[0])
+        line_data = LineData(config, formatted_line, 0, file_path, "test_info", rule.patterns[0])
         assert line_data.value == "ngh679x"
         assert line_data.variable == var_name

--- a/tests/file_handler/test_byte_content_provider.py
+++ b/tests/file_handler/test_byte_content_provider.py
@@ -18,7 +18,7 @@ class TestByteContentProvider:
         content_provider = ByteContentProvider(lines_as_bytes)
         analysis_targets = content_provider.get_analysis_target()
 
-        expected_target = AnalysisTarget(lines[0], 1, lines, "")
+        expected_target = AnalysisTarget(lines[0], 1, lines, "", "")
 
         assert len(analysis_targets) == 2
 

--- a/tests/file_handler/test_diff_content_provider.py
+++ b/tests/file_handler/test_diff_content_provider.py
@@ -25,7 +25,7 @@ class TestDiffContentProvider:
         analysis_targets = content_provider.get_analysis_target()
 
         all_lines = ["", "new line", "moved line"]
-        expected_target = AnalysisTarget("new line", 2, all_lines, file_path)
+        expected_target = AnalysisTarget("new line", 2, all_lines, file_path, "added")
 
         assert len(analysis_targets) == 1
 

--- a/tests/file_handler/test_string_content_provider.py
+++ b/tests/file_handler/test_string_content_provider.py
@@ -14,7 +14,7 @@ class TestStringContentProvider:
         content_provider = StringContentProvider(lines)
         analysis_targets = content_provider.get_analysis_target()
 
-        expected_target = AnalysisTarget(lines[0], 1, lines, "")
+        expected_target = AnalysisTarget(lines[0], 1, lines, "", "")
 
         assert len(analysis_targets) == len(lines)
 

--- a/tests/file_handler/test_text_content_provider.py
+++ b/tests/file_handler/test_text_content_provider.py
@@ -16,7 +16,7 @@ class TestTextContentProvider:
         analysis_targets = content_provider.get_analysis_target()
 
         all_lines = ['password = "cackle!"', '']
-        expected_target = AnalysisTarget('password = "cackle!"', 1, all_lines, target_path)
+        expected_target = AnalysisTarget('password = "cackle!"', 1, all_lines, target_path, "")
 
         assert len(analysis_targets) == 2
 
@@ -32,7 +32,7 @@ class TestTextContentProvider:
             "Countries : ", "Country : ", "City : Seoul", "password : cackle!", "Country : ", "City : Kyiv",
             "password : peace_for_ukraine"
         ]
-        expected_target = AnalysisTarget("password : cackle!", 5, all_lines, target_path)
+        expected_target = AnalysisTarget("password : cackle!", 5, all_lines, target_path, "")
 
         assert len(analysis_targets) == 7
 
@@ -51,7 +51,7 @@ class TestTextContentProvider:
             analysis_targets = content_provider.get_analysis_target()
 
             all_lines = ["<password>crackle!</worng_grammar>"]
-            expected_target = AnalysisTarget("<password>crackle!</worng_grammar>", 1, all_lines, target_path)
+            expected_target = AnalysisTarget("<password>crackle!</worng_grammar>", 1, all_lines, target_path, "")
 
             assert len(analysis_targets) == 1
 

--- a/tests/ml_model/test_features.py
+++ b/tests/ml_model/test_features.py
@@ -43,36 +43,66 @@ def test_estimate_entropy_p():
 
 def test_word_in_secret_n():
     test = WordInSecret([])
-    ld = LineData(config=None, line="line", line_num=1, path="path", pattern=Util.get_keyword_pattern("password"))
+    ld = LineData(config=None,
+                  line="line",
+                  line_num=1,
+                  path="path",
+                  info="info",
+                  pattern=Util.get_keyword_pattern("password"))
     assert not test.extract(Candidate([ld], [], "rule", Severity.MEDIUM, [], True))
 
 
 def test_word_in_line_n():
     test = WordInLine([])
-    ld = LineData(config=None, line="line", line_num=1, path="path", pattern=Util.get_keyword_pattern("password"))
+    ld = LineData(config=None,
+                  line="line",
+                  line_num=1,
+                  path="path",
+                  info="info",
+                  pattern=Util.get_keyword_pattern("password"))
     assert not test.extract(Candidate([ld], [], "rule", Severity.MEDIUM, [], True))
 
 
 def test_word_in_path_n():
     test = WordInPath([])
-    ld = LineData(config=None, line="line", line_num=1, path="path", pattern=Util.get_keyword_pattern("password"))
+    ld = LineData(config=None,
+                  line="line",
+                  line_num=1,
+                  path="path",
+                  info="info",
+                  pattern=Util.get_keyword_pattern("password"))
     assert not test.extract(Candidate([ld], [], "rule", Severity.MEDIUM, [], True))
 
 
 def test_has_html_tag_n():
     test = HasHtmlTag()
-    ld = LineData(config=None, line="line", line_num=1, path="path", pattern=Util.get_keyword_pattern("password"))
+    ld = LineData(config=None,
+                  line="line",
+                  line_num=1,
+                  path="path",
+                  info="info",
+                  pattern=Util.get_keyword_pattern("password"))
     assert not test.extract(Candidate([ld], [], "rule", Severity.MEDIUM, [], True))
 
 
 def test_possible_comment_n():
     test = PossibleComment()
-    ld = LineData(config=None, line="line", line_num=1, path="path", pattern=Util.get_keyword_pattern("password"))
+    ld = LineData(config=None,
+                  line="line",
+                  line_num=1,
+                  path="path",
+                  info="info",
+                  pattern=Util.get_keyword_pattern("password"))
     assert not test.extract(Candidate([ld], [], "rule", Severity.MEDIUM, [], True))
 
 
 def test_is_secret_numeric_n():
     test = IsSecretNumeric()
-    ld = LineData(config=None, line="line", line_num=1, path="path", pattern=Util.get_keyword_pattern("password"))
+    ld = LineData(config=None,
+                  line="line",
+                  line_num=1,
+                  path="path",
+                  info="info",
+                  pattern=Util.get_keyword_pattern("password"))
     ld.value = 'dummy'
     assert not test.extract(Candidate([ld], [], "rule", Severity.MEDIUM, [], True))

--- a/tests/ml_model/test_ml_validator.py
+++ b/tests/ml_model/test_ml_validator.py
@@ -32,7 +32,12 @@ def test_ml_validator_simple_p():
     assert 0.240346 < probability < 0.240347
     assert not decision
 
-    candidate.line_data_list[0].path = "test.py.zip"
+    candidate.line_data_list[0].path = "test.zip"
     decision, probability = ml_validator.validate(candidate)
-    assert 0.51863 < probability < 0.51864
+    assert 0.51862 < probability < 0.51864
     assert not decision
+
+    candidate.line_data_list[0].path = "test.zip:test.py"
+    decision, probability = ml_validator.validate(candidate)
+    assert 0.919577 < probability < 0.919578
+    assert decision

--- a/tests/ml_model/test_ml_validator.py
+++ b/tests/ml_model/test_ml_validator.py
@@ -1,6 +1,38 @@
+from credsweeper import CREDSWEEPER_DIR, ThresholdPreset
+from credsweeper.config import Config
+from credsweeper.credentials import Candidate
 from credsweeper.ml_model import MlValidator
+from credsweeper.utils import Util
 
 
 def test_ml_validator_simple_p():
-    ml_validator = MlValidator(threshold=None)
+    ml_validator = MlValidator(threshold=ThresholdPreset.medium)
     assert ml_validator is not None
+    file_name = CREDSWEEPER_DIR / "secret" / "config.json"
+    config_dict = Util.json_load(file_name)
+    config_dict["validation"] = {}
+    config_dict["validation"]["api_validation"] = False
+    config_dict["use_filters"] = True
+    config_dict["find_by_ext"] = False
+    config_dict["depth"] = 0
+    config_dict["find_by_ext_list"] = []
+    config_dict["size_limit"] = None
+    config = Config(config_dict)
+    candidate = Candidate.get_dummy_candidate(config, "test.py")
+    candidate.line_data_list[0].line = '"geheimnis" : "Jhd2gH5634"'
+    candidate.line_data_list[0].variable = "geheimnis"
+    candidate.line_data_list[0].value = "Jhd2gH5634"
+
+    decision, probability = ml_validator.validate(candidate)
+    assert 0.919577 < probability < 0.919578
+    assert decision
+
+    candidate.line_data_list[0].path = "test.yaml"
+    decision, probability = ml_validator.validate(candidate)
+    assert 0.240346 < probability < 0.240347
+    assert not decision
+
+    candidate.line_data_list[0].path = "test.py.zip"
+    decision, probability = ml_validator.validate(candidate)
+    assert 0.240346 < probability < 0.51864
+    assert not decision

--- a/tests/ml_model/test_ml_validator.py
+++ b/tests/ml_model/test_ml_validator.py
@@ -34,5 +34,5 @@ def test_ml_validator_simple_p():
 
     candidate.line_data_list[0].path = "test.py.zip"
     decision, probability = ml_validator.validate(candidate)
-    assert 0.240346 < probability < 0.51864
+    assert 0.51863 < probability < 0.51864
     assert not decision

--- a/tests/rules/common.py
+++ b/tests/rules/common.py
@@ -9,12 +9,12 @@ class BaseTestRule:
 
     def test_scan_p(self, file_path: pytest.fixture, lines: pytest.fixture,
                     scanner_without_filters: pytest.fixture) -> None:
-        targets = [AnalysisTarget(line, i + 1, lines, file_path) for i, line in enumerate(lines)]
+        targets = [AnalysisTarget(line, i + 1, lines, file_path, "info") for i, line in enumerate(lines)]
         assert len(scanner_without_filters.scan(targets)) == 1
 
     @pytest.mark.parametrize("lines", [[""], ["String secret = new String()"], ["SZa6TWGF2XuWdl7c2s2xB1iSlnZJLbvH"]])
     def test_scan_n(self, file_path: pytest.fixture, lines: List[str], scanner: pytest.fixture) -> None:
-        targets = [AnalysisTarget(line, i + 1, lines, file_path) for i, line in enumerate(lines)]
+        targets = [AnalysisTarget(line, i + 1, lines, file_path, "info") for i, line in enumerate(lines)]
         assert len(scanner.scan(targets)) == 0
 
 
@@ -28,12 +28,12 @@ class BaseTestNoQuotesRule:
     """
 
     def test_scan_quote_p(self, file_path: pytest.fixture, lines: pytest.fixture, scanner: pytest.fixture) -> None:
-        targets = [AnalysisTarget(line, i + 1, lines, file_path) for i, line in enumerate(lines)]
+        targets = [AnalysisTarget(line, i + 1, lines, file_path, "info") for i, line in enumerate(lines)]
         assert len(scanner.scan(targets)) == 1
 
     def test_scan_quote_n(self, python_file_path: pytest.fixture, lines: pytest.fixture,
                           scanner: pytest.fixture) -> None:
-        targets = [AnalysisTarget(line, i + 1, lines, python_file_path) for i, line in enumerate(lines)]
+        targets = [AnalysisTarget(line, i + 1, lines, python_file_path, "info") for i, line in enumerate(lines)]
         assert len(scanner.scan(targets)) == 0
 
 
@@ -48,23 +48,23 @@ class BaseTestCommentRule:
 
     def test_scan_comment_p(self, python_file_path: pytest.fixture, lines: pytest.fixture,
                             scanner: pytest.fixture) -> None:
-        targets = [AnalysisTarget(line, i + 1, lines, python_file_path) for i, line in enumerate(lines)]
+        targets = [AnalysisTarget(line, i + 1, lines, python_file_path, "info") for i, line in enumerate(lines)]
         assert len(scanner.scan(targets)) == 1
 
     def test_scan_comment_n(self, python_file_path: pytest.fixture, lines: pytest.fixture,
                             scanner: pytest.fixture) -> None:
         lines = [f"\\{line}" for line in lines]
-        targets = [AnalysisTarget(line, i + 1, lines, python_file_path) for i, line in enumerate(lines)]
+        targets = [AnalysisTarget(line, i + 1, lines, python_file_path, "info") for i, line in enumerate(lines)]
         assert len(scanner.scan(targets)) == 0
 
 
 class BaseTestMultiRule:
 
     def test_scan_line_data_p(self, file_path: pytest.fixture, lines: pytest.fixture, scanner: pytest.fixture) -> None:
-        targets = [AnalysisTarget(line, i + 1, lines, file_path) for i, line in enumerate(lines)]
+        targets = [AnalysisTarget(line, i + 1, lines, file_path, "info") for i, line in enumerate(lines)]
         assert len(scanner.scan(targets)[0].line_data_list) == 2
 
     def test_scan_line_data_n(self, file_path: pytest.fixture, scanner: pytest.fixture) -> None:
         lines = [""]
-        targets = [AnalysisTarget(line, i + 1, lines, file_path) for i, line in enumerate(lines)]
+        targets = [AnalysisTarget(line, i + 1, lines, file_path, "info") for i, line in enumerate(lines)]
         assert len(scanner.scan(targets)) == 0

--- a/tests/rules/test_pem_key.py
+++ b/tests/rules/test_pem_key.py
@@ -88,5 +88,5 @@ class TestEmptyPemKey:
 
     def test_scan_no_division_by_zero_exception_n(self, file_path: pytest.fixture, lines: pytest.fixture,
                                                   scanner: pytest.fixture) -> None:
-        targets = [AnalysisTarget(line, i + 1, lines, file_path) for i, line in enumerate(lines)]
+        targets = [AnalysisTarget(line, i + 1, lines, file_path, "info") for i, line in enumerate(lines)]
         assert len(scanner.scan(targets)) == 0

--- a/tests/rules/test_token.py
+++ b/tests/rules/test_token.py
@@ -52,5 +52,5 @@ class TestTokenWhitespaceBeforeQuote:
 
     def test_scan_whitespace_before_quote_p(self, file_path: pytest.fixture, lines: pytest.fixture,
                                             scanner: pytest.fixture) -> None:
-        targets = [AnalysisTarget(line, i + 1, lines, file_path) for i, line in enumerate(lines)]
+        targets = [AnalysisTarget(line, i + 1, lines, file_path, "info") for i, line in enumerate(lines)]
         assert len(scanner.scan(targets)) == 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -265,7 +265,7 @@ class TestMain:
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
     def test_find_by_ext_and_not_ignore_p(self) -> None:
-        # checks only exactly match - may be wrong for windows
+        # checks only exact match (may be wrong for windows)
         config_dict = Util.json_load(CREDSWEEPER_DIR / "secret" / "config.json")
         assert config_dict
         find_by_ext_list_items = config_dict["find_by_ext_list"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,3 @@
-import json
 import os
 import random
 import tempfile
@@ -13,7 +12,7 @@ import pytest
 from credsweeper import ByteContentProvider, StringContentProvider, CREDSWEEPER_DIR
 from credsweeper import __main__ as app_main
 from credsweeper.app import CredSweeper
-from credsweeper.common.constants import DEFAULT_ENCODING, ThresholdPreset
+from credsweeper.common.constants import ThresholdPreset
 from credsweeper.credentials import Candidate
 from credsweeper.file_handler.files_provider import FilesProvider
 from credsweeper.file_handler.text_content_provider import TextContentProvider
@@ -199,9 +198,11 @@ class TestMain:
             app_main.main()
             assert os.path.exists(xlsx_filename)
             assert os.path.exists(json_filename)
-            with open(json_filename, "r") as json_file:
-                report = json.load(json_file)
-                assert len(report) == SAMPLES_CRED_COUNT
+            report = Util.json_load(json_filename)
+            assert report
+            assert len(report) == SAMPLES_CRED_COUNT
+            assert str(SAMPLES_DIR) in report[0]["line_data_list"][0]["path"]
+            assert "info" in report[0]["line_data_list"][0].keys()
             df = pd.read_excel(xlsx_filename)
             assert len(df) == SAMPLES_CRED_LINE_COUNT
 
@@ -265,15 +266,25 @@ class TestMain:
 
     def test_find_by_ext_and_not_ignore_p(self) -> None:
         # checks only exactly match - may be wrong for windows
-        with open(str(CREDSWEEPER_DIR / "secret" / "config.json"), "r", encoding=DEFAULT_ENCODING) as conf_file:
-            config_dict = json.load(conf_file)
-            extensions = config_dict["find_by_ext_list"]
-            assert isinstance(extensions, list)
-            assert len(extensions) > 0
-            ignores = config_dict["exclude"]["extension"]
-            assert isinstance(ignores, list)
-            extension_conflict = set(extensions).intersection(ignores)
-            assert len(extension_conflict) == 0, f"{extension_conflict}"
+        config_dict = Util.json_load(CREDSWEEPER_DIR / "secret" / "config.json")
+        assert config_dict
+        find_by_ext_list_items = config_dict["find_by_ext_list"]
+        assert isinstance(find_by_ext_list_items, list)
+        find_by_ext_list_set = set(find_by_ext_list_items)
+        assert len(find_by_ext_list_items) > 0
+        # check whether ignores extension are not exists in find_by_ext_list
+        exclude_extension_items = config_dict["exclude"]["extension"]
+        assert isinstance(exclude_extension_items, list)
+        extension_conflict = find_by_ext_list_set.intersection(exclude_extension_items)
+        assert len(extension_conflict) == 0, str({extension_conflict})
+        # check whether ignores containers are not exists in find_by_ext_list
+        exclude_containers_items = config_dict["exclude"]["containers"]
+        assert isinstance(exclude_containers_items, list)
+        containers_conflict = find_by_ext_list_set.intersection(exclude_containers_items)
+        assert len(containers_conflict) == 0, str({containers_conflict})
+        # check whether extension and containers have no duplicates
+        containers_extension_conflict = set(exclude_extension_items).intersection(exclude_containers_items)
+        assert len(containers_extension_conflict) == 0, str({containers_extension_conflict})
 
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -277,7 +277,7 @@ class TestMain:
         assert isinstance(exclude_extension_items, list)
         extension_conflict = find_by_ext_list_set.intersection(exclude_extension_items)
         assert len(extension_conflict) == 0, str({extension_conflict})
-        # check whether ignores containers are not exists in find_by_ext_list
+        # check whether ignored container does not exist in find_by_ext_list
         exclude_containers_items = config_dict["exclude"]["containers"]
         assert isinstance(exclude_containers_items, list)
         containers_conflict = find_by_ext_list_set.intersection(exclude_containers_items)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -272,7 +272,7 @@ class TestMain:
         assert isinstance(find_by_ext_list_items, list)
         find_by_ext_list_set = set(find_by_ext_list_items)
         assert len(find_by_ext_list_items) > 0
-        # check whether ignores extension are not exists in find_by_ext_list
+        # check whether ignored extension does not exist in find_by_ext_list
         exclude_extension_items = config_dict["exclude"]["extension"]
         assert isinstance(exclude_extension_items, list)
         extension_conflict = find_by_ext_list_set.intersection(exclude_extension_items)

--- a/tests/test_utils/dummy_line_data.py
+++ b/tests/test_utils/dummy_line_data.py
@@ -24,5 +24,5 @@ def config() -> Config:
 def get_line_data(file_path: str = "", line: str = "", pattern: str = r".*$", config: Config = config()) -> LineData:
     line_num = 0
     pattern = regex.compile(pattern)
-    line_data = LineData(config, line, line_num, file_path, pattern)
+    line_data = LineData(config, line, line_num, file_path, "info", pattern)
     return line_data

--- a/tests/utils/test_util.py
+++ b/tests/utils/test_util.py
@@ -21,6 +21,8 @@ class TestUtils(unittest.TestCase):
         self.assertEqual("", Util.get_extension("/tmp.ext/"))
 
     def test_get_extension_p(self):
+        self.assertEqual(".ext", Util.get_extension("c:\\tmp.ext"))
+        self.assertEqual(".json", Util.get_extension("c:\\tmp.ext:zip:text.json"))
         self.assertEqual(".ext", Util.get_extension("tmp.ext"))
         self.assertEqual(".jpg", Util.get_extension("tmp.JPG"))
         self.assertEqual(".ї", Util.get_extension("tmp.Ї", lower=True))

--- a/tests/utils/test_util.py
+++ b/tests/utils/test_util.py
@@ -3,6 +3,7 @@ import random
 import string
 import tempfile
 import unittest
+from pathlib import Path
 
 from credsweeper.common.constants import Chars, DEFAULT_ENCODING
 from credsweeper.utils import Util
@@ -21,8 +22,6 @@ class TestUtils(unittest.TestCase):
         self.assertEqual("", Util.get_extension("/tmp.ext/"))
 
     def test_get_extension_p(self):
-        self.assertEqual(".ext", Util.get_extension("c:\\tmp.ext"))
-        self.assertEqual(".json", Util.get_extension("c:\\tmp.ext:zip:text.json"))
         self.assertEqual(".ext", Util.get_extension("tmp.ext"))
         self.assertEqual(".jpg", Util.get_extension("tmp.JPG"))
         self.assertEqual(".ї", Util.get_extension("tmp.Ї", lower=True))
@@ -31,6 +30,19 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(".ㅋㅅ", Util.get_extension("tmp.ㅋㅅ"))
         self.assertEqual(".ß", Util.get_extension("tmp.ß"))
         self.assertEqual(".txt", Util.get_extension("/.hidden.tmp.txt"))
+
+    def test_colon_os(self):
+        self.assertEqual(".ext", Util.get_extension("c:\\tmp.ext"))
+        self.assertEqual(".json", Util.get_extension("c:\\tmp.ext:zip:text.json"))
+        self.assertEqual(".json", Util.get_extension("/tmp.ext:zip:text.json"))
+        self.assertEqual(".json:encoded", Util.get_extension("c:\\tmp.ext:zip:text.json:ENCODED"))
+        self.assertEqual(".json:raw", Util.get_extension("/tmp.ext:zip:text.json:raw"))
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_name = os.path.join(tmp_dir, "test_file.zip")
+            Path(file_name).touch()
+            assert os.path.exists(file_name)
+            new_name = f"{file_name}:ZIP:dummy.txt"
+            assert not os.path.exists(new_name)
 
     def test_get_shannon_entropy_n(self):
         self.assertEqual(0, Util.get_shannon_entropy("", "abc"))
@@ -288,9 +300,10 @@ class TestUtils(unittest.TestCase):
         lines = Util.get_xml_data(target_path)
 
         assert lines == ([
-            "Countries : ", "Country : ", "City : Seoul", "password : cackle!", "Country : ", "City : Kyiv",
-            "password : peace_for_ukraine"
-        ], [2, 3, 4, 5, 7, 8, 9])
+                             "Countries : ", "Country : ", "City : Seoul", "password : cackle!", "Country : ",
+                             "City : Kyiv",
+                             "password : peace_for_ukraine"
+                         ], [2, 3, 4, 5, 7, 8, 9])
 
     def test_json_load_p(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/utils/test_util.py
+++ b/tests/utils/test_util.py
@@ -300,10 +300,9 @@ class TestUtils(unittest.TestCase):
         lines = Util.get_xml_data(target_path)
 
         assert lines == ([
-                             "Countries : ", "Country : ", "City : Seoul", "password : cackle!", "Country : ",
-                             "City : Kyiv",
-                             "password : peace_for_ukraine"
-                         ], [2, 3, 4, 5, 7, 8, 9])
+            "Countries : ", "Country : ", "City : Seoul", "password : cackle!", "Country : ", "City : Kyiv",
+            "password : peace_for_ukraine"
+        ], [2, 3, 4, 5, 7, 8, 9])
 
     def test_json_load_p(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/validation/test_validation.py
+++ b/tests/validation/test_validation.py
@@ -51,8 +51,9 @@ def mocked_requests_post(*args, **kwargs):
 def test_mocked_validation_n(validator):
     candidate = Candidate(
         line_data_list=[  #
-            LineData({}, line="dummy line 1", line_num=1, path="dummy path 1", pattern=regex.compile('.*')),
-            LineData({}, line="dummy line 2", line_num=2, path="dummy path 2", pattern=regex.compile('.*'))
+            LineData({}, line="dummy line 1", line_num=1, path="dummy path 1", info="info",
+                     pattern=regex.compile('.*')),
+            LineData({}, line="dummy line 2", line_num=2, path="dummy path 2", info="info", pattern=regex.compile('.*'))
         ],
         patterns=[regex.compile('.*')],  #
         rule_name="Dummy candidate",  #
@@ -75,8 +76,9 @@ def test_mocked_validation_n(validator):
 def test_google_multi_n():
     candidate = Candidate(
         line_data_list=[  #
-            LineData({}, line="dummy line 1", line_num=1, path="dummy path 1", pattern=regex.compile('.*')),
-            LineData({}, line="dummy line 2", line_num=2, path="dummy path 2", pattern=regex.compile('.*'))
+            LineData({}, line="dummy line 1", line_num=1, path="dummy path 1", info="info",
+                     pattern=regex.compile('.*')),
+            LineData({}, line="dummy line 2", line_num=2, path="dummy path 2", info="info", pattern=regex.compile('.*'))
         ],
         patterns=[regex.compile('.*')],  #
         rule_name="Dummy candidate",  #
@@ -102,7 +104,7 @@ def mocked_requests_get_403(*args, **kwargs):
 def test_stripe_validation_n():
     candidate = Candidate(
         line_data_list=[  #
-            LineData({}, line="dummy line 1", line_num=1, path="dummy path 1", pattern=regex.compile('.*'))
+            LineData({}, line="dummy line 1", line_num=1, path="dummy path 1", info="info", pattern=regex.compile('.*'))
         ],
         patterns=[regex.compile('.*')],  #
         rule_name="Dummy candidate",  #


### PR DESCRIPTION
## Description

- INFO field was added to inform user which way credentials were found. "Virtual" files in containers cannot be found. 

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] watch 'info' field after credsweeeper usage with --depth option

MERGE AFTER #224 
