### PR TITLE
Fix test help p error

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -95,7 +95,7 @@ jobs:
       id: setup_python
       uses: actions/setup-python@v3
       with:
-        python-version: "3.9"
+        python-version: "3.10"
 
     - name: Install CredSweeper and auxiliary packages
       id: setup_credsweeper
@@ -131,6 +131,10 @@ jobs:
       if: ${{ always() && steps.setup_credsweeper.conclusion == 'success' }}
       run: pylint --py-version=3.9 --errors-only credsweeper
 
+    - name: Analysing the code with pylint and minimum Python version 3.10
+      if: ${{ always() && steps.setup_credsweeper.conclusion == 'success' }}
+      run: pylint --py-version=3.10 --errors-only credsweeper
+
     # # # mypy
 
     - name: Analysing the code with mypy and minimum Python version 3.7
@@ -144,6 +148,10 @@ jobs:
     - name: Analysing the code with mypy and minimum Python version 3.9
       if: ${{ always() && steps.setup_credsweeper.conclusion == 'success' }}
       run: mypy --config-file .mypy.ini --python-version=3.9 credsweeper | LC_ALL=C sort -g | diff cicd/mypy_warnings.txt -
+
+    - name: Analysing the code with mypy and minimum Python version 3.10
+      if: ${{ always() && steps.setup_credsweeper.conclusion == 'success' }}
+      run: mypy --config-file .mypy.ini --python-version=3.10 credsweeper | LC_ALL=C sort -g | diff cicd/mypy_warnings.txt -
 
     # # # documentation
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -95,7 +95,7 @@ jobs:
       id: setup_python
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.9"
 
     - name: Install CredSweeper and auxiliary packages
       id: setup_credsweeper

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
 
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Full documentation can be found here: <https://credsweeper.readthedocs.io/>
 
 ### Main Requirements
 
-- Python 3.7, 3.8, 3.9
+- Python 3.7, 3.8, 3.9, 3.10
 
 ### Installation
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -3,7 +3,7 @@ Installation
 
 Currently `CredSweeper` requires the following prerequisites:
 
-* Python version 3.7, 3.8, 3.9
+* Python version 3.7, 3.8, 3.9, 3.10
 
 .. note::
     We recommend to use credsweeper in a separate virtual enviroment. Some heave dependencies as Tensorflow

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",  #
         "Programming Language :: Python :: 3.8",  #
         "Programming Language :: Python :: 3.9",  #
+        "Programming Language :: Python :: 3.10",  #
         "License :: OSI Approved :: MIT License",  #
         "Operating System :: OS Independent",  #
         "Topic :: Security",  #

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -274,7 +274,8 @@ class TestApp(TestCase):
                     continue
                 if started:
                     # There is argparse change on python3.10 to display just "options:"
-                    if line.strip() == "optional arguments:":
+                    if sys.version_info.major == 3 and sys.version_info.minor >= 10 \
+                        and line.strip() == "optional arguments:":
                         text += line.replace("optional arguments:", "options:")
                     else:
                         text += line

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -273,7 +273,10 @@ class TestApp(TestCase):
                     started = True
                     continue
                 if started:
-                    text += line
+                    if line.strip() == "optional arguments:":
+                        text += line.replace("optional arguments:", "options:")
+                    else:
+                        text += line
             expected = " ".join(text.split())
             assert output == expected
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -273,6 +273,7 @@ class TestApp(TestCase):
                     started = True
                     continue
                 if started:
+                    # There is argparse change on python3.10 to display just "options:"
                     if line.strip() == "optional arguments:":
                         text += line.replace("optional arguments:", "options:")
                     else:


### PR DESCRIPTION
## Description

There is an error in `test_help_p()` method which in `tests/test_app.py` when I trying to run pytest with python3.10.x version.
I investigated the error and I found there is a change on `argparse`.
https://docs.python.org/3/whatsnew/3.10.html#argparse

Following the document ***Misleading phrase “optional arguments” was replaced with “options” in argparse help.*** so I replaced "optional arguemnts" to "options" in `test_help_p()`.

- Fix `test_help_p()` error

## How has this been tested?

- [X] Pytest finished without error
