### PR TITLE
Fix github action to check last release

### DIFF
--- a/.github/workflows/rottenness.yml
+++ b/.github/workflows/rottenness.yml
@@ -57,6 +57,6 @@ jobs:
 
     - name: Compare source code of versions
       if: env.TAG_NAME
-      run: diff ${{ env.TAG_NAME }}/credsweeper ${{ github.event.repository.default_branch }}/credsweeper
+      run: diff --recursive ${{ env.TAG_NAME }}/credsweeper ${{ github.event.repository.default_branch }}/credsweeper
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/.github/workflows/rottenness.yml
+++ b/.github/workflows/rottenness.yml
@@ -31,7 +31,7 @@ jobs:
             release_age=0
         fi
         tag_name=$(echo "${latest_release}" | jq --raw-output '.tag_name')
-        if [ $(( 60 * 60 * 24 * 14 )) -gt ${release_age} ]; then
+        if [ $(( 60 * 60 * 24 * 28 )) -gt ${release_age} ]; then
             echo "Release is fresh"
             echo "TAG_NAME=" >> $GITHUB_ENV
         else


### PR DESCRIPTION
## Description

- applied recursive scan for source folder - bugfix of CI workflow
- increased period for obsolete release to 28 days. The PR is pass, but on next Monday (25th) it should fail. Then we do release and then may reduce the period again.

## How has this been tested?

- [ ] Check manually after 4 weeks 
