### PR TITLE
File type is extracted to separated field for deep scan

### DIFF
--- a/cicd/missed_docstrings.txt
+++ b/cicd/missed_docstrings.txt
@@ -12,4 +12,3 @@ credsweeper/filters/group/group.py:51:4: C0116: Missing function or method docst
 credsweeper/filters/group/password_keyword.py:7:0: C0115: Missing class docstring (missing-class-docstring)
 credsweeper/filters/group/pem_pattern.py:7:0: C0115: Missing class docstring (missing-class-docstring)
 credsweeper/filters/group/url_credentials_group.py:10:0: C0115: Missing class docstring (missing-class-docstring)
-credsweeper/ml_model/features.py:28:4: C0116: Missing function or method docstring (missing-function-docstring)

--- a/credsweeper/credentials/candidate.py
+++ b/credsweeper/credentials/candidate.py
@@ -180,18 +180,10 @@ class Candidate:
         return reported_output
 
     @classmethod
-    def get_dummy_candidate(cls, config: Config, file_path: str):
+    def get_dummy_candidate(cls, config: Config, file_path: str, file_type: str, info: str):
         """Create dummy instance to use in searching file by extension"""
         return cls(  #
-            line_data_list=[  #
-                LineData(  #
-                    config,  #
-                    line="dummy line",  #
-                    line_num=-1,  #
-                    path=file_path,  #
-                    info="dummy info",  #
-                    pattern=regex.compile(".*"))
-            ],
+            line_data_list=[LineData(config, "dummy line", -1, file_path, file_type, info, regex.compile(".*"))],
             patterns=[regex.compile(".*")],  #
             rule_name="Dummy candidate",  #
             severity=Severity.INFO,  #

--- a/credsweeper/credentials/line_data.py
+++ b/credsweeper/credentials/line_data.py
@@ -14,6 +14,7 @@ class LineData:
         line: string variable, line
         line_num: int variable, number of line in file
         path: string variable, path to file
+        file_type: string variable, extension of file '.txt'
         info: additional info about how the data was detected
         pattern: regex pattern, detected pattern in line
         separator: optional string variable, separators between variable and value
@@ -26,12 +27,21 @@ class LineData:
     comment_starts = ["//", "*", "#", "/*", "<!––", "%{", "%", "...", "(*", "--", "--[[", "#="]
     bash_param_split = regex.compile("\\s+(\\-|\\||\\>|\\w+?\\>|\\&)")
 
-    def __init__(self, config: Config, line: str, line_num: int, path: str, info: str, pattern: regex.Pattern) -> None:
+    def __init__(
+            self,  #
+            config: Config,  #
+            line: str,  #
+            line_num: int,  #
+            path: str,  #
+            file_type: str,  #
+            info: str,  #
+            pattern: regex.Pattern) -> None:
         self.config = config
         self.key: Optional[str] = None
         self.line: str = line
         self.line_num: int = line_num
         self.path: str = path
+        self.file_type: str = file_type
         self.info: str = info
         self.pattern: regex.Pattern = pattern
         self.separator: Optional[str] = None
@@ -82,6 +92,16 @@ class LineData:
     def path(self, path: str) -> None:
         """path setter"""
         self.__path = path
+
+    @property
+    def file_type(self) -> str:
+        """file_type getter"""
+        return self.__file_type
+
+    @file_type.setter
+    def file_type(self, file_type: str) -> None:
+        """file_type setter"""
+        self.__file_type = file_type
 
     @property
     def info(self) -> str:

--- a/credsweeper/file_handler/analysis_target.py
+++ b/credsweeper/file_handler/analysis_target.py
@@ -8,4 +8,5 @@ class AnalysisTarget:
     line_num: int
     lines: List[str]
     file_path: str
+    file_type: str
     info: str

--- a/credsweeper/file_handler/byte_content_provider.py
+++ b/credsweeper/file_handler/byte_content_provider.py
@@ -15,8 +15,13 @@ class ByteContentProvider(ContentProvider):
 
     """
 
-    def __init__(self, content: bytes, file_path: Optional[str] = None, info: Optional[str] = None) -> None:
-        super().__init__(file_path, info)
+    def __init__(
+            self,  #
+            content: bytes,  #
+            file_path: Optional[str] = None,  #
+            file_type: Optional[str] = None,  #
+            info: Optional[str] = None) -> None:
+        super().__init__(file_path=file_path, file_type=file_type, info=info)
         self.lines = Util.decode_bytes(content)
 
     def get_analysis_target(self) -> List[AnalysisTarget]:

--- a/credsweeper/file_handler/content_provider.py
+++ b/credsweeper/file_handler/content_provider.py
@@ -2,13 +2,19 @@ from abc import ABC, abstractmethod
 from typing import List, Optional
 
 from credsweeper.file_handler.analysis_target import AnalysisTarget
+from credsweeper.utils import Util
 
 
 class ContentProvider(ABC):
     """Base class to provide access to analysis targets for scanned object."""
 
-    def __init__(self, file_path: Optional[str] = None, info: Optional[str] = None) -> None:
+    def __init__(
+            self,  #
+            file_path: Optional[str] = None,  #
+            file_type: Optional[str] = None,  #
+            info: Optional[str] = None) -> None:
         self.file_path: str = file_path
+        self.file_type: str = file_type if file_type else Util.get_extension(file_path)
         self.info: str = info
 
     @abstractmethod
@@ -32,6 +38,16 @@ class ContentProvider(ABC):
         self.__file_path = _file_path if _file_path else ""
 
     @property
+    def file_type(self) -> str:
+        """file_type getter"""
+        return self.__file_type
+
+    @file_type.setter
+    def file_type(self, _file_type: str) -> None:
+        """file_type setter"""
+        self.__file_type = _file_type if _file_type else ""
+
+    @property
     def info(self) -> str:
         """info getter"""
         return self.__info
@@ -46,10 +62,10 @@ class ContentProvider(ABC):
         targets = []
         if line_nums:
             for line, line_num in zip(lines, line_nums):
-                target = AnalysisTarget(line, line_num, lines, self.file_path, self.info)
+                target = AnalysisTarget(line, line_num, lines, self.file_path, self.file_type, self.info)
                 targets.append(target)
         else:
             for i, line in enumerate(lines):
-                target = AnalysisTarget(line, i + 1, lines, self.file_path, self.info)
+                target = AnalysisTarget(line, i + 1, lines, self.file_path, self.file_type, self.info)
                 targets.append(target)
         return targets

--- a/credsweeper/file_handler/data_content_provider.py
+++ b/credsweeper/file_handler/data_content_provider.py
@@ -13,8 +13,13 @@ class DataContentProvider(ContentProvider):
 
     """
 
-    def __init__(self, data: bytes, file_path: Optional[str] = None, info: Optional[str] = None) -> None:
-        super().__init__(file_path, info)
+    def __init__(
+            self,  #
+            data: bytes,  #
+            file_path: Optional[str] = None,  #
+            file_type: Optional[str] = None,  #
+            info: Optional[str] = None) -> None:
+        super().__init__(file_path=file_path, file_type=file_type, info=info)
         self.data = data
 
     @property

--- a/credsweeper/file_handler/diff_content_provider.py
+++ b/credsweeper/file_handler/diff_content_provider.py
@@ -23,7 +23,7 @@ class DiffContentProvider(ContentProvider):
     """
 
     def __init__(self, file_path: str, change_type: str, diff: List[DiffDict]) -> None:
-        super().__init__(file_path)
+        super().__init__(file_path=file_path)
         self.change_type = change_type
         self.diff = diff
 
@@ -61,6 +61,6 @@ class DiffContentProvider(ContentProvider):
         lines_data = Util.preprocess_file_diff(self.diff)
         change_numbs, all_lines = self.parse_lines_data(lines_data)
         return [
-            AnalysisTarget(all_lines[l_numb - 1], l_numb, all_lines, self.file_path, self.change_type)
+            AnalysisTarget(all_lines[l_numb - 1], l_numb, all_lines, self.file_path, self.file_type, self.change_type)
             for l_numb in change_numbs
         ]

--- a/credsweeper/file_handler/file_path_extractor.py
+++ b/credsweeper/file_handler/file_path_extractor.py
@@ -98,18 +98,18 @@ class FilePathExtractor:
                 parent_directory = new_parent
 
     @staticmethod
-    def is_find_by_ext_file(config: Config, path: str) -> bool:
+    def is_find_by_ext_file(config: Config, extension: str) -> bool:
         """
         Checks whether file has suspicious extension
 
         Args:
             config: Config
-            path: str - may be only file name with extension
+            extension: str - may be only file name with extension
 
         Return:
             True when the feature is configured and the file extension matches
         """
-        return config.find_by_ext and Util.get_extension(path) in config.find_by_ext_list
+        return config.find_by_ext and extension in config.find_by_ext_list
 
     @classmethod
     def check_exclude_file(cls, config: Config, path: str) -> bool:

--- a/credsweeper/file_handler/string_content_provider.py
+++ b/credsweeper/file_handler/string_content_provider.py
@@ -13,8 +13,13 @@ class StringContentProvider(ContentProvider):
 
     """
 
-    def __init__(self, lines: List[str], file_path: Optional[str] = None, info: Optional[str] = None) -> None:
-        super().__init__(file_path, info)
+    def __init__(
+            self,  #
+            lines: List[str],  #
+            file_path: Optional[str] = None,  #
+            file_type: Optional[str] = None,  #
+            info: Optional[str] = None) -> None:
+        super().__init__(file_path=file_path, file_type=file_type, info=info)
         self.lines = lines
 
     def get_analysis_target(self) -> List[AnalysisTarget]:
@@ -24,4 +29,7 @@ class StringContentProvider(ContentProvider):
             list of analysis targets based on every row in file
 
         """
-        return [AnalysisTarget(line, i + 1, self.lines, self.file_path, self.info) for i, line in enumerate(self.lines)]
+        return [
+            AnalysisTarget(line, i + 1, self.lines, self.file_path, self.file_type, self.info)
+            for i, line in enumerate(self.lines)
+        ]

--- a/credsweeper/file_handler/text_content_provider.py
+++ b/credsweeper/file_handler/text_content_provider.py
@@ -16,8 +16,12 @@ class TextContentProvider(ContentProvider):
 
     """
 
-    def __init__(self, file_path: str) -> None:
-        super().__init__(file_path)
+    def __init__(
+            self,
+            file_path: str,  #
+            file_type: Optional[str] = None,  #
+            info: Optional[str] = None) -> None:
+        super().__init__(file_path=file_path, file_type=file_type, info=info)
 
     def get_analysis_target(self) -> List[AnalysisTarget]:
         """Load and preprocess file content to scan.

--- a/credsweeper/ml_model/features.py
+++ b/credsweeper/ml_model/features.py
@@ -1,6 +1,5 @@
 """Most rules are described in 'Secrets in Source Code: Reducing False Positives Using Machine Learning'."""
 
-import os.path
 from abc import ABC, abstractmethod
 from typing import List, Any, Dict
 
@@ -26,6 +25,7 @@ class Feature(ABC):
 
     @abstractmethod
     def extract(self, candidate: Candidate) -> Any:
+        """Abstract method of base class"""
         raise NotImplementedError
 
 
@@ -208,7 +208,7 @@ class FileExtension(Feature):
     def __call__(self, candidates: List[Candidate]) -> csr_matrix:
         enc = LabelBinarizer()
         enc.fit(self.extensions)
-        extensions = [os.path.splitext(candidate.line_data_list[0].path)[1] for candidate in candidates]
+        extensions = [candidate.line_data_list[0].file_type for candidate in candidates]
         return enc.transform(extensions)
 
     def extract(self, candidate: Candidate) -> Any:

--- a/credsweeper/scanner/scan_type/multi_pattern.py
+++ b/credsweeper/scanner/scan_type/multi_pattern.py
@@ -80,6 +80,7 @@ class MultiPattern(ScanType):
                                       line=candi_line,
                                       line_num=candi_line_num,
                                       file_path=target.file_path,
+                                      file_type=target.file_type,
                                       info=target.info,
                                       pattern=rule.patterns[1],
                                       filters=rule.filters)

--- a/credsweeper/scanner/scan_type/scan_type.py
+++ b/credsweeper/scanner/scan_type/scan_type.py
@@ -64,8 +64,16 @@ class ScanType(ABC):
         return False
 
     @classmethod
-    def get_line_data(cls, config: Config, line: str, line_num: int, file_path: str, info: str, pattern: regex.Pattern,
-                      filters: List[Filter]) -> Optional[LineData]:
+    def get_line_data(
+            cls,  #
+            config: Config,  #
+            line: str,  #
+            line_num: int,  #
+            file_path: str,  #
+            file_type: str,  #
+            info: str,  #
+            pattern: regex.Pattern,  #
+            filters: List[Filter]) -> Optional[LineData]:
         """Check if regex pattern is present in line, and line should not be removed by filters.
 
         Args:
@@ -73,6 +81,7 @@ class ScanType(ABC):
             line: Line to check
             line_num: Line number of a current line
             file_path: Path to the file that contain current line
+            file_type: Type of file in extension '.txt'
             info: Extended info
             pattern: Compiled regex object to be searched in line
             filters: Filters to use
@@ -84,7 +93,7 @@ class ScanType(ABC):
         if not cls.is_valid_line(line, pattern, line_num, file_path):
             return None
         logger.debug("Valid line for pattern: %s in file: %s:%d in line: %s", pattern, file_path, line_num, line)
-        line_data = LineData(config=config, line=line, line_num=line_num, path=file_path, info=info, pattern=pattern)
+        line_data = LineData(config, line, line_num, file_path, file_type, info, pattern)
 
         if cls.filtering(config, line_data, filters):
             return None
@@ -162,6 +171,7 @@ class ScanType(ABC):
                                       line=target.line,
                                       line_num=target.line_num,
                                       file_path=target.file_path,
+                                      file_type=target.file_type,
                                       info=target.info,
                                       pattern=rule.patterns[0],
                                       filters=rule.filters)

--- a/credsweeper/utils/util.py
+++ b/credsweeper/utils/util.py
@@ -43,7 +43,7 @@ class Util:
     @staticmethod
     def get_extension(file_path: str, lower=True) -> str:
         """Return extension of file in lower case by default e.g.: '.txt', '.JPG'"""
-        _, extension = os.path.splitext(file_path)
+        _, extension = os.path.splitext(str(file_path))
         return extension.lower() if lower else extension
 
     @staticmethod

--- a/tests/common/test_constants.py
+++ b/tests/common/test_constants.py
@@ -10,7 +10,7 @@ class TestConstants:
     @pytest.mark.parametrize("line", ["melon = 'banAna'", "melon : 'banAna'", "melon := 'banAna'"])
     def test_separator_common_p(self, config: Config, file_path: pytest.fixture, line: str) -> None:
         pattern = Util.get_keyword_pattern("melon")
-        line_data = LineData(config, line, 1, file_path, info="dummy", pattern=pattern)
+        line_data = LineData(config, line, 1, file_path, Util.get_extension(file_path), info="dummy", pattern=pattern)
         assert line_data.value == "banAna"
 
     @pytest.mark.parametrize("line, value",
@@ -20,5 +20,5 @@ class TestConstants:
                               ["'password': 'ENC[lqjdoxlandicpfpqk]'", "ENC[lqjdoxlandicpfpqk]"]])
     def test_keyword_pattern_common_p(self, config: Config, file_path: pytest.fixture, line: str, value: str) -> None:
         pattern = Util.get_keyword_pattern("password")
-        line_data = LineData(config, line, 1, file_path, info="dummy", pattern=pattern)
+        line_data = LineData(config, line, 1, file_path, Util.get_extension(file_path), info="dummy", pattern=pattern)
         assert line_data.value == value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ def config() -> Config:
     config_dict["use_filters"] = True
     config_dict["find_by_ext"] = False
     config_dict["depth"] = 0
-    config_dict["find_by_ext_list"] = [".txt"]
+    config_dict["find_by_ext_list"] = [".txt", ".inf"]
     config_dict["size_limit"] = None
     return Config(config_dict)
 

--- a/tests/credentials/test_credential_manager.py
+++ b/tests/credentials/test_credential_manager.py
@@ -10,7 +10,7 @@ class TestCredentialManager:
         "line", ["apiKeyToken = 'mybstscrt'", "SecretToken = 'mybstscrt'", "secret = AKIAGIREOGIAWSKEY123"])
     def test_groups_p(self, line):
         cred_sweeper = CredSweeper()
-        targets = [AnalysisTarget(line, i + 1, [line], "", "") for i, line in enumerate([line])]
+        targets = [AnalysisTarget(line, i + 1, [line], "", "", "") for i, line in enumerate([line])]
         detections = cred_sweeper.scanner.scan(targets)
         cred_sweeper.credential_manager.set_credentials(detections)
         groups = cred_sweeper.credential_manager.group_credentials()
@@ -23,7 +23,7 @@ class TestCredentialManager:
     ])
     def test_groups_n(self, line):
         cred_sweeper = CredSweeper()
-        targets = [AnalysisTarget(line, i + 1, [line], "", "") for i, line in enumerate([line])]
+        targets = [AnalysisTarget(line, i + 1, [line], "", "", "") for i, line in enumerate([line])]
         detections = cred_sweeper.scanner.scan(targets)
         cred_sweeper.credential_manager.set_credentials(detections)
         groups = cred_sweeper.credential_manager.group_credentials()

--- a/tests/credentials/test_line_data.py
+++ b/tests/credentials/test_line_data.py
@@ -2,6 +2,7 @@ import pytest
 
 from credsweeper.config import Config
 from credsweeper.credentials import LineData
+from credsweeper.utils import Util
 
 
 class TestLineData:
@@ -20,7 +21,8 @@ class TestLineData:
         Rerun few times with different variable names to assure that different rules behave in a same way
         """
         formatted_line = line.format(var_name)
-        line_data = LineData(config, formatted_line, 0, file_path, "test_info", rule.patterns[0])
+        line_data = LineData(config, formatted_line, 0, file_path, Util.get_extension(file_path), "test_info",
+                             rule.patterns[0])
         assert line_data.value == "ngh679x"
         assert line_data.variable == var_name
 
@@ -31,7 +33,8 @@ class TestLineData:
                            rule_name: str, config: Config) -> None:
         """Check that most simple case for credentials is parsed correctly"""
         formatted_line = line.format(var_name)
-        line_data = LineData(config, formatted_line, 0, file_path, "test_info", rule.patterns[0])
+        line_data = LineData(config, formatted_line, 0, file_path, Util.get_extension(file_path), "test_info",
+                             rule.patterns[0])
         assert line_data.value == "ngh679x"
         assert line_data.variable == var_name
 
@@ -41,7 +44,7 @@ class TestLineData:
     def test_multiple_word_variable_name_p(self, file_path: pytest.fixture, rule: pytest.fixture, line: str,
                                            varname: str, rule_name: str, config: Config) -> None:
         """Check that if variable name contain spaces (like field in JSON) it would be parsed correctly"""
-        line_data = LineData(config, line, 0, file_path, "test_info", rule.patterns[0])
+        line_data = LineData(config, line, 0, file_path, Util.get_extension(file_path), "test_info", rule.patterns[0])
         assert line_data.value == "ngh679x"
         assert line_data.variable == varname
 
@@ -53,7 +56,8 @@ class TestLineData:
                              rule_name: str, config: Config) -> None:
         """Check that secrets in function arguments parsed in a correct way (without argument name)"""
         formatted_line = line.format(var_name)
-        line_data = LineData(config, formatted_line, 0, file_path, "test_info", rule.patterns[0])
+        line_data = LineData(config, formatted_line, 0, file_path, Util.get_extension(file_path), "test_info",
+                             rule.patterns[0])
         assert line_data.value == "ngh679x"
         assert line_data.variable == var_name
 
@@ -68,7 +72,8 @@ class TestLineData:
                                  rule_name: str, config: Config) -> None:
         """Check that secrets in function arguments parsed in a correct way (with argument name)"""
         formatted_line = line.format(var_name)
-        line_data = LineData(config, formatted_line, 0, file_path, "test_info", rule.patterns[0])
+        line_data = LineData(config, formatted_line, 0, file_path, Util.get_extension(file_path), "test_info",
+                             rule.patterns[0])
         assert line_data.value == "ngh679x"
         assert line_data.variable == var_name
 
@@ -87,6 +92,7 @@ class TestLineData:
                              rule_name: str, config: Config) -> None:
         """Check credentials declared in CLI arguments"""
         formatted_line = line.format(var_name)
-        line_data = LineData(config, formatted_line, 0, file_path, "test_info", rule.patterns[0])
+        line_data = LineData(config, formatted_line, 0, file_path, Util.get_extension(file_path), "test_info",
+                             rule.patterns[0])
         assert line_data.value == "ngh679x"
         assert line_data.variable == var_name

--- a/tests/file_handler/test_byte_content_provider.py
+++ b/tests/file_handler/test_byte_content_provider.py
@@ -18,7 +18,7 @@ class TestByteContentProvider:
         content_provider = ByteContentProvider(lines_as_bytes)
         analysis_targets = content_provider.get_analysis_target()
 
-        expected_target = AnalysisTarget(lines[0], 1, lines, "", "")
+        expected_target = AnalysisTarget(lines[0], 1, lines, "", "", "")
 
         assert len(analysis_targets) == 2
 

--- a/tests/file_handler/test_diff_content_provider.py
+++ b/tests/file_handler/test_diff_content_provider.py
@@ -25,7 +25,7 @@ class TestDiffContentProvider:
         analysis_targets = content_provider.get_analysis_target()
 
         all_lines = ["", "new line", "moved line"]
-        expected_target = AnalysisTarget("new line", 2, all_lines, file_path, "added")
+        expected_target = AnalysisTarget("new line", 2, all_lines, file_path, ".file", "added")
 
         assert len(analysis_targets) == 1
 

--- a/tests/file_handler/test_file_path_extractor.py
+++ b/tests/file_handler/test_file_path_extractor.py
@@ -61,16 +61,16 @@ class TestFilePathExtractor:
         config.find_by_ext = True
         assert FilePathExtractor.check_exclude_file(config, file_path)
 
-    @pytest.mark.parametrize("file_path", ["/tmp/test.txt", "dummy.txt"])
-    def test_find_by_ext_file_p(self, config: Config, file_path: pytest.fixture) -> None:
+    @pytest.mark.parametrize("file_type", [".inf", ".txt"])
+    def test_find_by_ext_file_p(self, config: Config, file_type: pytest.fixture) -> None:
         config.find_by_ext = True
-        assert FilePathExtractor.is_find_by_ext_file(config, file_path)
+        assert FilePathExtractor.is_find_by_ext_file(config, file_type)
 
-    @pytest.mark.parametrize("file_path", ["/tmp/test.bmp", "dummy.doc"])
-    def test_find_by_ext_file_n(self, config: Config, file_path: pytest.fixture) -> None:
-        assert not FilePathExtractor.is_find_by_ext_file(config, file_path)
+    @pytest.mark.parametrize("file_type", [".bmp", ".doc"])
+    def test_find_by_ext_file_n(self, config: Config, file_type: pytest.fixture) -> None:
+        assert not FilePathExtractor.is_find_by_ext_file(config, file_type)
         config.find_by_ext = False
-        assert not FilePathExtractor.is_find_by_ext_file(config, file_path)
+        assert not FilePathExtractor.is_find_by_ext_file(config, file_type)
 
     @mock.patch("os.path.getsize")
     def test_check_file_size_p(self, mock_getsize: Mock(), config: Config) -> None:

--- a/tests/file_handler/test_string_content_provider.py
+++ b/tests/file_handler/test_string_content_provider.py
@@ -14,7 +14,7 @@ class TestStringContentProvider:
         content_provider = StringContentProvider(lines)
         analysis_targets = content_provider.get_analysis_target()
 
-        expected_target = AnalysisTarget(lines[0], 1, lines, "", "")
+        expected_target = AnalysisTarget(lines[0], 1, lines, "", "", "")
 
         assert len(analysis_targets) == len(lines)
 

--- a/tests/file_handler/test_text_content_provider.py
+++ b/tests/file_handler/test_text_content_provider.py
@@ -16,7 +16,7 @@ class TestTextContentProvider:
         analysis_targets = content_provider.get_analysis_target()
 
         all_lines = ['password = "cackle!"', '']
-        expected_target = AnalysisTarget('password = "cackle!"', 1, all_lines, target_path, "")
+        expected_target = AnalysisTarget('password = "cackle!"', 1, all_lines, target_path, "", "")
 
         assert len(analysis_targets) == 2
 
@@ -32,7 +32,7 @@ class TestTextContentProvider:
             "Countries : ", "Country : ", "City : Seoul", "password : cackle!", "Country : ", "City : Kyiv",
             "password : peace_for_ukraine"
         ]
-        expected_target = AnalysisTarget("password : cackle!", 5, all_lines, target_path, "")
+        expected_target = AnalysisTarget("password : cackle!", 5, all_lines, target_path, ".xml", "")
 
         assert len(analysis_targets) == 7
 
@@ -51,7 +51,8 @@ class TestTextContentProvider:
             analysis_targets = content_provider.get_analysis_target()
 
             all_lines = ["<password>crackle!</worng_grammar>"]
-            expected_target = AnalysisTarget("<password>crackle!</worng_grammar>", 1, all_lines, target_path, "")
+            expected_target = AnalysisTarget("<password>crackle!</worng_grammar>", 1, all_lines, target_path, ".xml",
+                                             "")
 
             assert len(analysis_targets) == 1
 

--- a/tests/filters/test_value_string_type_check.py
+++ b/tests/filters/test_value_string_type_check.py
@@ -14,32 +14,37 @@ class TestValueStringTypeCheck:
     def test_value_string_type_check_p(self, line: str, config: Config) -> None:
         file_path = "path.py"
         pattern = Util.get_keyword_pattern("test")
-        line_data = get_line_data(file_path, line=line, pattern=pattern, config=config)
+        line_data = get_line_data(config, file_path, line=line, pattern=pattern)
         assert ValueStringTypeCheck(config).run(line_data) is False
 
     @pytest.mark.parametrize("line", fail_line)
     def test_value_string_type_check_n(self, line: str, config: Config) -> None:
         file_path = "path.py"
         pattern = Util.get_keyword_pattern("test")
-        line_data = get_line_data(file_path, line=line, pattern=pattern, config=config)
+        line_data = get_line_data(config, file_path, line=line, pattern=pattern)
         assert ValueStringTypeCheck(config).run(line_data) is True
 
     @pytest.mark.parametrize("line", success_lines)
     def test_value_string_type_check_none_path_n(self, line: str, config: Config) -> None:
         file_path = None
         pattern = Util.get_keyword_pattern("test")
-        line_data = get_line_data(file_path, line=line, pattern=pattern, config=config)
+        line_data = get_line_data(config, file_path, line=line, pattern=pattern)
         assert ValueStringTypeCheck(config).run(line_data) is True
 
     @pytest.mark.parametrize("line", fail_line)
     def test_value_string_type_check_not_quoted_source_file_p(self, line: str, config: Config) -> None:
         file_path = "path.yaml"
         pattern = Util.get_keyword_pattern("test")
-        line_data = get_line_data(file_path, line=line, pattern=pattern, config=config)
+        line_data = get_line_data(
+            config,
+            file_path,
+            line=line,
+            pattern=pattern,
+        )
         assert ValueStringTypeCheck(config).run(line_data) is False
 
     @pytest.mark.parametrize("line", success_lines)
     def test_value_string_type_check_none_value_n(self, line: str, config: Config) -> None:
         file_path = "path.py"
-        line_data = get_line_data(file_path, line=line)
+        line_data = get_line_data(config, file_path, line=line)
         assert ValueStringTypeCheck(config).run(line_data) is True

--- a/tests/ml_model/test_features.py
+++ b/tests/ml_model/test_features.py
@@ -47,6 +47,7 @@ def test_word_in_secret_n():
                   line="line",
                   line_num=1,
                   path="path",
+                  file_type="type",
                   info="info",
                   pattern=Util.get_keyword_pattern("password"))
     assert not test.extract(Candidate([ld], [], "rule", Severity.MEDIUM, [], True))
@@ -58,6 +59,7 @@ def test_word_in_line_n():
                   line="line",
                   line_num=1,
                   path="path",
+                  file_type="type",
                   info="info",
                   pattern=Util.get_keyword_pattern("password"))
     assert not test.extract(Candidate([ld], [], "rule", Severity.MEDIUM, [], True))
@@ -69,6 +71,7 @@ def test_word_in_path_n():
                   line="line",
                   line_num=1,
                   path="path",
+                  file_type="type",
                   info="info",
                   pattern=Util.get_keyword_pattern("password"))
     assert not test.extract(Candidate([ld], [], "rule", Severity.MEDIUM, [], True))
@@ -80,6 +83,7 @@ def test_has_html_tag_n():
                   line="line",
                   line_num=1,
                   path="path",
+                  file_type="type",
                   info="info",
                   pattern=Util.get_keyword_pattern("password"))
     assert not test.extract(Candidate([ld], [], "rule", Severity.MEDIUM, [], True))
@@ -91,6 +95,7 @@ def test_possible_comment_n():
                   line="line",
                   line_num=1,
                   path="path",
+                  file_type="type",
                   info="info",
                   pattern=Util.get_keyword_pattern("password"))
     assert not test.extract(Candidate([ld], [], "rule", Severity.MEDIUM, [], True))
@@ -102,6 +107,7 @@ def test_is_secret_numeric_n():
                   line="line",
                   line_num=1,
                   path="path",
+                  file_type="type",
                   info="info",
                   pattern=Util.get_keyword_pattern("password"))
     ld.value = 'dummy'

--- a/tests/ml_model/test_ml_validator.py
+++ b/tests/ml_model/test_ml_validator.py
@@ -18,7 +18,7 @@ def test_ml_validator_simple_p():
     config_dict["find_by_ext_list"] = []
     config_dict["size_limit"] = None
     config = Config(config_dict)
-    candidate = Candidate.get_dummy_candidate(config, "test.py")
+    candidate = Candidate.get_dummy_candidate(config, "test.py", ".py", "test_info")
     candidate.line_data_list[0].line = '"geheimnis" : "Jhd2gH5634"'
     candidate.line_data_list[0].variable = "geheimnis"
     candidate.line_data_list[0].value = "Jhd2gH5634"
@@ -28,16 +28,19 @@ def test_ml_validator_simple_p():
     assert decision
 
     candidate.line_data_list[0].path = "test.yaml"
+    candidate.line_data_list[0].file_type = ".yaml"
     decision, probability = ml_validator.validate(candidate)
     assert 0.240346 < probability < 0.240347
     assert not decision
 
     candidate.line_data_list[0].path = "test.zip"
+    candidate.line_data_list[0].file_type = ".zip"
     decision, probability = ml_validator.validate(candidate)
     assert 0.51862 < probability < 0.51864
     assert not decision
 
-    candidate.line_data_list[0].path = "test.zip:test.py"
+    candidate.line_data_list[0].path = "test.zip bla bla bla"
+    candidate.line_data_list[0].file_type = ".py"
     decision, probability = ml_validator.validate(candidate)
     assert 0.919577 < probability < 0.919578
     assert decision

--- a/tests/rules/common.py
+++ b/tests/rules/common.py
@@ -3,18 +3,25 @@ from typing import List
 import pytest
 
 from credsweeper.file_handler.analysis_target import AnalysisTarget
+from credsweeper.utils import Util
 
 
 class BaseTestRule:
 
     def test_scan_p(self, file_path: pytest.fixture, lines: pytest.fixture,
                     scanner_without_filters: pytest.fixture) -> None:
-        targets = [AnalysisTarget(line, i + 1, lines, file_path, "info") for i, line in enumerate(lines)]
+        targets = [
+            AnalysisTarget(line, i + 1, lines, file_path, Util.get_extension(file_path), "info")
+            for i, line in enumerate(lines)
+        ]
         assert len(scanner_without_filters.scan(targets)) == 1
 
     @pytest.mark.parametrize("lines", [[""], ["String secret = new String()"], ["SZa6TWGF2XuWdl7c2s2xB1iSlnZJLbvH"]])
     def test_scan_n(self, file_path: pytest.fixture, lines: List[str], scanner: pytest.fixture) -> None:
-        targets = [AnalysisTarget(line, i + 1, lines, file_path, "info") for i, line in enumerate(lines)]
+        targets = [
+            AnalysisTarget(line, i + 1, lines, file_path, Util.get_extension(file_path), "info")
+            for i, line in enumerate(lines)
+        ]
         assert len(scanner.scan(targets)) == 0
 
 
@@ -28,12 +35,18 @@ class BaseTestNoQuotesRule:
     """
 
     def test_scan_quote_p(self, file_path: pytest.fixture, lines: pytest.fixture, scanner: pytest.fixture) -> None:
-        targets = [AnalysisTarget(line, i + 1, lines, file_path, "info") for i, line in enumerate(lines)]
+        targets = [
+            AnalysisTarget(line, i + 1, lines, file_path, Util.get_extension(file_path), "info")
+            for i, line in enumerate(lines)
+        ]
         assert len(scanner.scan(targets)) == 1
 
     def test_scan_quote_n(self, python_file_path: pytest.fixture, lines: pytest.fixture,
                           scanner: pytest.fixture) -> None:
-        targets = [AnalysisTarget(line, i + 1, lines, python_file_path, "info") for i, line in enumerate(lines)]
+        targets = [
+            AnalysisTarget(line, i + 1, lines, python_file_path, Util.get_extension(python_file_path), "info")
+            for i, line in enumerate(lines)
+        ]
         assert len(scanner.scan(targets)) == 0
 
 
@@ -48,23 +61,35 @@ class BaseTestCommentRule:
 
     def test_scan_comment_p(self, python_file_path: pytest.fixture, lines: pytest.fixture,
                             scanner: pytest.fixture) -> None:
-        targets = [AnalysisTarget(line, i + 1, lines, python_file_path, "info") for i, line in enumerate(lines)]
+        targets = [
+            AnalysisTarget(line, i + 1, lines, python_file_path, Util.get_extension(python_file_path), "info")
+            for i, line in enumerate(lines)
+        ]
         assert len(scanner.scan(targets)) == 1
 
     def test_scan_comment_n(self, python_file_path: pytest.fixture, lines: pytest.fixture,
                             scanner: pytest.fixture) -> None:
         lines = [f"\\{line}" for line in lines]
-        targets = [AnalysisTarget(line, i + 1, lines, python_file_path, "info") for i, line in enumerate(lines)]
+        targets = [
+            AnalysisTarget(line, i + 1, lines, python_file_path, Util.get_extension(python_file_path), "info")
+            for i, line in enumerate(lines)
+        ]
         assert len(scanner.scan(targets)) == 0
 
 
 class BaseTestMultiRule:
 
     def test_scan_line_data_p(self, file_path: pytest.fixture, lines: pytest.fixture, scanner: pytest.fixture) -> None:
-        targets = [AnalysisTarget(line, i + 1, lines, file_path, "info") for i, line in enumerate(lines)]
+        targets = [
+            AnalysisTarget(line, i + 1, lines, file_path, Util.get_extension(file_path), "info")
+            for i, line in enumerate(lines)
+        ]
         assert len(scanner.scan(targets)[0].line_data_list) == 2
 
     def test_scan_line_data_n(self, file_path: pytest.fixture, scanner: pytest.fixture) -> None:
         lines = [""]
-        targets = [AnalysisTarget(line, i + 1, lines, file_path, "info") for i, line in enumerate(lines)]
+        targets = [
+            AnalysisTarget(line, i + 1, lines, file_path, Util.get_extension(file_path), "info")
+            for i, line in enumerate(lines)
+        ]
         assert len(scanner.scan(targets)) == 0

--- a/tests/rules/test_pem_key.py
+++ b/tests/rules/test_pem_key.py
@@ -3,6 +3,7 @@ from typing import List
 import pytest
 
 from credsweeper.file_handler.analysis_target import AnalysisTarget
+from credsweeper.utils import Util
 from .common import BaseTestRule
 
 
@@ -88,5 +89,8 @@ class TestEmptyPemKey:
 
     def test_scan_no_division_by_zero_exception_n(self, file_path: pytest.fixture, lines: pytest.fixture,
                                                   scanner: pytest.fixture) -> None:
-        targets = [AnalysisTarget(line, i + 1, lines, file_path, "info") for i, line in enumerate(lines)]
+        targets = [
+            AnalysisTarget(line, i + 1, lines, file_path, Util.get_extension(file_path), "info")
+            for i, line in enumerate(lines)
+        ]
         assert len(scanner.scan(targets)) == 0

--- a/tests/rules/test_token.py
+++ b/tests/rules/test_token.py
@@ -3,6 +3,7 @@ from typing import List
 import pytest
 
 from credsweeper.file_handler.analysis_target import AnalysisTarget
+from credsweeper.utils import Util
 from .common import BaseTestCommentRule, BaseTestNoQuotesRule, BaseTestRule
 
 
@@ -52,5 +53,8 @@ class TestTokenWhitespaceBeforeQuote:
 
     def test_scan_whitespace_before_quote_p(self, file_path: pytest.fixture, lines: pytest.fixture,
                                             scanner: pytest.fixture) -> None:
-        targets = [AnalysisTarget(line, i + 1, lines, file_path, "info") for i, line in enumerate(lines)]
+        targets = [
+            AnalysisTarget(line, i + 1, lines, file_path, Util.get_extension(file_path), "info")
+            for i, line in enumerate(lines)
+        ]
         assert len(scanner.scan(targets)) == 1

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -237,8 +237,9 @@ class TestApp(TestCase):
             elif 13 <= len(line) and "Time Elapsed:" == line[0:13]:
                 assert re.match(r"Time Elapsed: \d+\.\d+", line), line
             else:
-                assert re.match(r"\d{4}-\d\d-\d\d \d\d:\d\d:\d\d,\d+ \| (DEBUG|INFO|WARNING|ERROR) \| \w+:\d+ \| .*",
-                                line), line
+                self.assertRegex(line,
+                                 r"\d{4}-\d\d-\d\d \d\d:\d\d:\d\d,\d+ \| (DEBUG|INFO|WARNING|ERROR) \| \w+:\d+ \| .*",
+                                 line)
 
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 

--- a/tests/test_utils/dummy_line_data.py
+++ b/tests/test_utils/dummy_line_data.py
@@ -6,6 +6,7 @@ from credsweeper import CREDSWEEPER_DIR
 from credsweeper.common.constants import DEFAULT_ENCODING
 from credsweeper.config import Config
 from credsweeper.credentials import LineData
+from credsweeper.utils import Util
 
 
 def config() -> Config:
@@ -21,8 +22,9 @@ def config() -> Config:
     return Config(config_dict)
 
 
-def get_line_data(file_path: str = "", line: str = "", pattern: str = r".*$", config: Config = config()) -> LineData:
+def get_line_data(test_config: Config = config(), file_path: str = "", line: str = "",
+                  pattern: regex.Pattern = r".*$") -> LineData:
     line_num = 0
     pattern = regex.compile(pattern)
-    line_data = LineData(config, line, line_num, file_path, "info", pattern)
+    line_data = LineData(test_config, line, line_num, file_path, Util.get_extension(file_path), "info", pattern)
     return line_data

--- a/tests/utils/test_util.py
+++ b/tests/utils/test_util.py
@@ -13,6 +13,7 @@ from tests import AZ_DATA, AZ_STRING, SAMPLES_DIR
 class TestUtils(unittest.TestCase):
 
     def test_get_extension_n(self):
+        self.assertEqual("", Util.get_extension(None))
         self.assertEqual("", Util.get_extension("/"))
         self.assertEqual("", Util.get_extension("/tmp"))
         self.assertEqual("", Util.get_extension("tmp"))

--- a/tests/validation/test_validation.py
+++ b/tests/validation/test_validation.py
@@ -51,9 +51,20 @@ def mocked_requests_post(*args, **kwargs):
 def test_mocked_validation_n(validator):
     candidate = Candidate(
         line_data_list=[  #
-            LineData({}, line="dummy line 1", line_num=1, path="dummy path 1", info="info",
+            LineData({},
+                     line="dummy line 1",
+                     line_num=1,
+                     path="dummy path 1",
+                     file_type=".type1",
+                     info="info",
                      pattern=regex.compile('.*')),
-            LineData({}, line="dummy line 2", line_num=2, path="dummy path 2", info="info", pattern=regex.compile('.*'))
+            LineData({},
+                     line="dummy line 2",
+                     line_num=2,
+                     path="dummy path 2",
+                     file_type=".type2",
+                     info="info",
+                     pattern=regex.compile('.*'))
         ],
         patterns=[regex.compile('.*')],  #
         rule_name="Dummy candidate",  #
@@ -76,9 +87,20 @@ def test_mocked_validation_n(validator):
 def test_google_multi_n():
     candidate = Candidate(
         line_data_list=[  #
-            LineData({}, line="dummy line 1", line_num=1, path="dummy path 1", info="info",
+            LineData({},
+                     line="dummy line 1",
+                     line_num=1,
+                     path="dummy path 1",
+                     file_type=".type1",
+                     info="info",
                      pattern=regex.compile('.*')),
-            LineData({}, line="dummy line 2", line_num=2, path="dummy path 2", info="info", pattern=regex.compile('.*'))
+            LineData({},
+                     line="dummy line 2",
+                     line_num=2,
+                     path="dummy path 2",
+                     file_type=".type2",
+                     info="info",
+                     pattern=regex.compile('.*'))
         ],
         patterns=[regex.compile('.*')],  #
         rule_name="Dummy candidate",  #
@@ -104,7 +126,13 @@ def mocked_requests_get_403(*args, **kwargs):
 def test_stripe_validation_n():
     candidate = Candidate(
         line_data_list=[  #
-            LineData({}, line="dummy line 1", line_num=1, path="dummy path 1", info="info", pattern=regex.compile('.*'))
+            LineData({},
+                     line="dummy line 1",
+                     line_num=1,
+                     path="dummy path 1",
+                     file_type=".type1",
+                     info="info",
+                     pattern=regex.compile('.*'))
         ],
         patterns=[regex.compile('.*')],  #
         rule_name="Dummy candidate",  #


### PR DESCRIPTION
## Description
- use separated field ``file_type`` to send it into MlValidator as is. It helps to apply correct feature for ml model during deep scan when file_path is kept unchanged but the file contains another files with different type.

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] File path in report must be equal real file name. Info field contains path how the credential was found
