### PR TITLE
Propagate size limit config to PatchProvider

### DIFF
--- a/credsweeper/file_handler/file_path_extractor.py
+++ b/credsweeper/file_handler/file_path_extractor.py
@@ -151,7 +151,9 @@ class FilePathExtractor:
         """
         if config.size_limit is None:
             return False
-        if os.path.getsize(path) > config.size_limit:
+        file_size = os.path.getsize(path)
+        if file_size > config.size_limit:
+            logger.warning(f"Size ({file_size}) of the file '{path}' is over limit ({config.size_limit})")
             return True
         else:
             return False

--- a/credsweeper/file_handler/patch_provider.py
+++ b/credsweeper/file_handler/patch_provider.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Union
 from credsweeper import TextContentProvider
 from credsweeper.config import Config
 from credsweeper.file_handler.diff_content_provider import DiffContentProvider
+from credsweeper.file_handler.file_path_extractor import FilePathExtractor
 from credsweeper.file_handler.files_provider import FilesProvider
 from credsweeper.utils import Util
 
@@ -36,10 +37,12 @@ class PatchProvider(FilesProvider):
         self.paths = paths
         self.change_type = change_type
 
-    def load_patch_data(self) -> List[List[str]]:
+    def load_patch_data(self, config: Config) -> List[List[str]]:
         """Loads data from patch"""
         raw_patches = []
         for file_path in self.paths:
+            if FilePathExtractor.check_file_size(config, file_path):
+                continue
             raw_patches.append(Util.read_file(file_path))
         return raw_patches
 
@@ -62,6 +65,6 @@ class PatchProvider(FilesProvider):
             file objects for analysing
 
         """
-        diff_data = self.load_patch_data()
+        diff_data = self.load_patch_data(config)
         files = self.get_files_sequence(diff_data)
         return files

--- a/tests/file_handler/test_patch_provider.py
+++ b/tests/file_handler/test_patch_provider.py
@@ -1,18 +1,18 @@
-from unittest import mock
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
+from credsweeper.config import Config
 from credsweeper.file_handler.patch_provider import PatchProvider
 from tests import SAMPLES_DIR
 
 
 class TestPatchProvider:
 
-    def test_load_patch_data_p(self) -> None:
+    def test_load_patch_data_p(self, config: Config) -> None:
         """Evaluate base load diff file"""
         file_path = SAMPLES_DIR / "password.patch"
         patch_provider = PatchProvider([str(file_path)], "added")
 
-        raw_patches = patch_provider.load_patch_data()
+        raw_patches = patch_provider.load_patch_data(config)
 
         expected = [[
             'diff --git a/.changes/1.16.98.json b/.changes/1.16.98.json',  #
@@ -31,13 +31,13 @@ class TestPatchProvider:
 
         assert raw_patches == expected
 
-    def test_load_patch_data_utf16_n(self) -> None:
+    def test_load_patch_data_utf16_n(self, config: Config) -> None:
         """Evaluate load diff file with UTF-16 encoding"""
         file_path = SAMPLES_DIR / "password_utf16.patch"
         patch_provider = PatchProvider([str(file_path)], "added")
 
         with patch('logging.Logger.info') as mocked_logger:
-            raw_patches = patch_provider.load_patch_data()
+            raw_patches = patch_provider.load_patch_data(config)
             warning_message = f"UnicodeError: Can't read content from \"{file_path}\" as utf8."
             mocked_logger.assert_called_with(warning_message)
 
@@ -58,13 +58,13 @@ class TestPatchProvider:
         ]]
         assert raw_patches == expected
 
-    def test_load_patch_data_western_n(self) -> None:
+    def test_load_patch_data_western_n(self, config: Config) -> None:
         """Evaluate load diff file with Western encoding"""
         file_path = SAMPLES_DIR / "password_western.patch"
         patch_provider = PatchProvider([str(file_path)], "added")
 
         with patch('logging.Logger.info') as mocked_logger:
-            raw_patches = patch_provider.load_patch_data()
+            raw_patches = patch_provider.load_patch_data(config)
             warning_message = f"UnicodeError: Can't read content from \"{file_path}\" as utf16."
             mocked_logger.assert_called_with(warning_message)
 
@@ -84,14 +84,13 @@ class TestPatchProvider:
         ]]
         assert raw_patches == expected
 
-    @mock.patch("logging.info")
-    def test_load_patch_data_n(self, mock_logging_info: Mock()) -> None:
+    def test_load_patch_data_n(self, config: Config) -> None:
         """Evaluate warning occurrence while load diff file with ISO-IR-111 encoding"""
         file_path = SAMPLES_DIR / "iso_ir_111.patch"
         patch_provider = PatchProvider([str(file_path)], "added")
 
         with patch('logging.Logger.info') as mocked_logger:
-            raw_patches = patch_provider.load_patch_data()
+            raw_patches = patch_provider.load_patch_data(config)
             warning_message = f"UnicodeError: Can't read content from \"{file_path}\" as utf16."
             mocked_logger.assert_called_with(warning_message)
 
@@ -111,3 +110,17 @@ class TestPatchProvider:
             ''  #
         ]]
         assert raw_patches == expected
+
+    def test_oversize_n(self, config: Config) -> None:
+        """Evaluate warning occurrence while load oversize diff file"""
+        file_path = SAMPLES_DIR / "password.patch"
+        patch_provider = PatchProvider([str(file_path)], "added")
+
+        config.size_limit = 0
+        with patch('logging.Logger.warning') as mocked_logger:
+            raw_patches = patch_provider.load_patch_data(config)
+            warning_message = f"Size (232) of the file '{file_path}' is over limit (0)"
+            mocked_logger.assert_called_with(warning_message)
+
+        assert isinstance(raw_patches, list)
+        assert len(raw_patches) == 0

--- a/tests/file_handler/test_patch_provider.py
+++ b/tests/file_handler/test_patch_provider.py
@@ -113,13 +113,14 @@ class TestPatchProvider:
 
     def test_oversize_n(self, config: Config) -> None:
         """Evaluate warning occurrence while load oversize diff file"""
-        file_path = SAMPLES_DIR / "password.patch"
+        # use UTF-16 encoding to prevent any Windows style transformation
+        file_path = SAMPLES_DIR / "password_utf16.patch"
         patch_provider = PatchProvider([str(file_path)], "added")
 
         config.size_limit = 0
         with patch('logging.Logger.warning') as mocked_logger:
             raw_patches = patch_provider.load_patch_data(config)
-            warning_message = f"Size (232) of the file '{file_path}' is over limit (0)"
+            warning_message = f"Size (512) of the file '{file_path}' is over limit (0)"
             mocked_logger.assert_called_with(warning_message)
 
         assert isinstance(raw_patches, list)


### PR DESCRIPTION
## Description

- Use configured param ``size_limit`` in PatchProvider to skip too big diffs which are computed a long time with ``whatthepath``

## How has this been tested?

- [x] UnitTests
- [x] Set size limit less than a diff size and run credsweeper for scan the diff. Warning about oversize should appear.
