### PR TITLE
Change trigger for release

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
     branches: [ main ]
   release:
-    types: [created]
+    types: [ released ]
 
 jobs:
   deploy:


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release

## Description

- Modified trigger for release - the workflow will run when release issued (not pre-release)

## How has this been tested?


- [x] with new release.
