### PR TITLE
 Add SLSA Release step in pypi.yml

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -55,7 +55,7 @@ jobs:
       id: download
       uses: samsung/supplychainassurance/.github/actions/download-artifact@v1.0.2
       with:
-        hash: ${{ needs.Release.outputs.hash }}
+        hash: ${{ needs.build.outputs.hash }}
 
     - name: Set up Python
       uses: actions/setup-python@v3

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -49,9 +49,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [ build, slsa_release, upload_asset ]
-    if: ${{ 'release' == github.event_name }}
     steps:
     - name: Download Artifacts
+      if: ${{ 'release' == github.event_name }}
       id: download
       uses: samsung/supplychainassurance/.github/actions/download-artifact@v1.0.2
       with:
@@ -68,6 +68,7 @@ jobs:
         pip install twine
 
     - name: Publish
+      if: ${{ 'release' == github.event_name }}
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
@@ -76,6 +77,7 @@ jobs:
         twine upload ${{ needs.build.outputs.artifact }}
 
     - name: Test for creation sphinx documentations
+      if: ${{ 'release' != github.event_name }}
       run: |
         python --version
         pip install -r requirements.txt

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -12,14 +12,50 @@ on:
     types: [ released ]
 
 jobs:
-  deploy:
+  build:
+    uses: samsung/supplychainassurance/.github/workflows/python_builder.yml@v1.0.2
+    with:
+      version: "3.10"
+      upload: ${{ 'release' == github.event_name }}
 
+  slsa_release:
+    needs: [ build ]
+    if: ${{ 'release' == github.event_name }}
+    permissions:
+      id-token: write
+    uses: samsung/supplychainassurance/.github/workflows/slsa_release.yml@v1.0.2
+    with:
+      hash: "${{ needs.build.outputs.hash }}"
+      artifact: "${{ needs.build.outputs.artifact }}"
+      build_cmd: "${{ needs.build.outputs.build_command }}"
+    secrets:
+      EXPECTED_REPOSITORY: "${{ secrets.EXPECTED_REPOSITORY }}"
+      ECODETOKEN: "${{ secrets.ECODE_TOKEN }}"
+
+  upload_asset:
+    needs: [ build, slsa_release ]
+    if: ${{ 'release' == github.event_name }}
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
+    - name: Upload Assets
+      uses: samsung/supplychainassurance/.github/actions/upload-release-asset@v1.0.2
+      env:
+        GITHUBTOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        artifacts: ${{ needs.slsa_release.outputs.artifacts }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [ build, slsa_release, upload_asset ]
+    if: ${{ 'release' == github.event_name }}
+    steps:
+    - name: Download Artifacts
+      id: download
+      uses: samsung/supplychainassurance/.github/actions/download-artifact@v1.0.2
+      with:
+        hash: ${{ needs.Release.outputs.hash }}
 
     - name: Set up Python
       uses: actions/setup-python@v3
@@ -29,22 +65,17 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-
-    - name: Build
-      run: |
-        python setup.py sdist bdist_wheel
+        pip install twine
 
     - name: Publish
-      if: ${{ 'release' == github.event_name }}
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run:
-        twine upload dist/*
+      run: |
+        cd ${{ steps.download.outputs.outdir }}
+        twine upload ${{ needs.build.outputs.artifact }}
 
     - name: Test for creation sphinx documentations
-      if: ${{ 'release' != github.event_name }}
       run: |
         python --version
         pip install -r requirements.txt


### PR DESCRIPTION
## Description
SLSA release steps is implemented as reusable-workflow in Samsung/SupplyChainAssurance/.github/workflow/

If use it, below files will be uploaded as assets of release
 - whl, tar.gz for pypi
 - an SBOM(spdx type)
 - an Attestation(slsa provenance)

This PR is different from e7ca9de10f7cd633d1e71329fb72ace3348891fc
 - python_builder worklfow is used instead of python_releasor. 
   python_builder workflow runs by pull_request/push/released events
 - slsa_release/upload-assets runs only by released events

## How has this been tested?
Check release assets after release
