### PR TITLE
onnxruntime fix for Python 3.9.16 in macos

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -39,3 +39,6 @@ ignore_missing_imports = True
 
 [mypy-whatthepatch.*]
 ignore_missing_imports = True
+
+[mypy-setuptools.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
     description="Credential Sweeper",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=setuptools.find_packages(include=("credsweeper*",)),
+    packages=setuptools.find_packages(include=("credsweeper*", )),
     package_data={
         "credsweeper": [
             "py.typed",  #

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,13 @@
+import sys
+
 import setuptools
 
 with open("README.md", "r", encoding="utf8") as fh:
     long_description = fh.read()
+
+onnxruntime_pkg = "onnxruntime"
+if "darwin" == sys.platform and 9 == sys.version_info.minor:
+    onnxruntime_pkg += "<=1.13.1"
 
 install_requires = [
     "GitPython",  #
@@ -19,7 +25,7 @@ install_requires = [
     "whatthepatch",  #
     "numpy",  #
     "scikit-learn",  #
-    "onnxruntime"  #
+    onnxruntime_pkg  #
 ]
 
 setuptools.setup(
@@ -27,7 +33,7 @@ setuptools.setup(
     description="Credential Sweeper",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=setuptools.find_packages(include=("credsweeper*", )),
+    packages=setuptools.find_packages(include=("credsweeper*",)),
     package_data={
         "credsweeper": [
             "py.typed",  #

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ with open("README.md", "r", encoding="utf8") as fh:
 
 onnxruntime_pkg = "onnxruntime"
 if "darwin" == sys.platform and 9 == sys.version_info.minor:
+    # workaround for https://github.com/microsoft/onnxruntime/issues/14663
+    # onnxruntime v1.14.0 for macos with Python3.9.16 has package issue (have (arm64), need (x86_64)))
     onnxruntime_pkg += "<=1.13.1"
 
 install_requires = [


### PR DESCRIPTION
## Description

- workaround for issue for macos Python 3.9.16 (pip23) and latest version of onnxruntime v1.14.0
https://github.com/microsoft/onnxruntime/issues/14663

## How has this been tested?


- [x] GitHub actions pass