### PR TITLE
Credit card number rule and filter

### DIFF
--- a/cicd/benchmark.txt
+++ b/cicd/benchmark.txt
@@ -1,5 +1,5 @@
-Detected Credentials: 4456
-result_cnt : 4062, lost_cnt : 70, true_cnt : 3665, false_cnt : 327
+Detected Credentials: 4464
+result_cnt : 4070, lost_cnt : 78, true_cnt : 3665, false_cnt : 327
 credsweeper -> TP : 3665, FP : 327, TN : 19429556, FN : 910, FPR : 0.0000168297, FNR : 0.1989071038, ACC : 0.9999363502, PRC : 0.9180861723, RCL : 0.8010928962, F1 : 0.8556087312
 credsweeper Private Key -> TP : 952, FP : 0, TN : 4, FN : 39, FPR : None, FNR : 0.0393541877, ACC : 0.9608040201, PRC : 1.0000000000, RCL : 0.9606458123, F1 : 0.9799279465
 credsweeper Predefined Pattern -> TP : 307, FP : 2, TN : 40, FN : 19, FPR : 0.0476190476, FNR : 0.0582822086, ACC : 0.9429347826, PRC : 0.9935275081, RCL : 0.9417177914, F1 : 0.9669291339

--- a/credsweeper/filters/cred_card_number_check.py
+++ b/credsweeper/filters/cred_card_number_check.py
@@ -1,0 +1,39 @@
+from credsweeper.credentials import LineData
+from credsweeper.filters import Filter
+
+
+class CreditCardNumberCheck(Filter):
+    """Check that value is a credit card number."""
+
+    def run(self, line_data: LineData) -> bool:
+        """Run filter checks on received credential candidate data 'line_data'.
+
+        Args:
+            line_data: credential candidate data
+
+        Return:
+            False, if the sequence is not card number. True if it is
+
+        """
+        if line_data.value is None \
+                or 16 != len(line_data.value) \
+                or ("0" == line_data.value[0] and "0" == line_data.value[1]):
+            return True
+        try:
+            s = 0
+            # https://en.wikipedia.org/wiki/Luhn_algorithm
+            for n in range(0, 16):
+                x = int(line_data.value[n])
+                if 0 == (1 & n):  # Only for odd numbers (with 0 as a start index)
+                    x *= 2
+                    if x > 9:
+                        x -= 9
+                s += x
+
+            if 0 == s % 10:
+                return False
+        except ValueError:
+            pass
+
+        # return False when the sequence is not a credit card number
+        return True

--- a/credsweeper/filters/group/__init__.py
+++ b/credsweeper/filters/group/__init__.py
@@ -5,3 +5,4 @@ from credsweeper.filters.group.general_pattern import GeneralPattern
 from credsweeper.filters.group.password_keyword import PasswordKeyword
 from credsweeper.filters.group.pem_pattern import PEMPattern
 from credsweeper.filters.group.url_credentials_group import UrlCredentialsGroup
+from credsweeper.filters.group.credit_card_number_sequense import CreditCardNumberSequence

--- a/credsweeper/filters/group/credit_card_number_sequense.py
+++ b/credsweeper/filters/group/credit_card_number_sequense.py
@@ -1,0 +1,15 @@
+from credsweeper.common.constants import GroupType
+from credsweeper.config import Config
+from credsweeper.filters.cred_card_number_check import CreditCardNumberCheck
+from credsweeper.filters.group import Group
+
+
+class CreditCardNumberSequence(Group):
+    """NumberSequence credentials group class.
+
+    Applied credit card sequence filter
+    """
+
+    def __init__(self, config: Config) -> None:
+        super().__init__(config, GroupType.PATTERN)
+        self.filters = [CreditCardNumberCheck()]

--- a/credsweeper/rules/config.yaml
+++ b/credsweeper/rules/config.yaml
@@ -1,3 +1,13 @@
+- name: Credit card number
+  severity: medium
+  type: pattern
+  values:
+    - (?<!([0-9]\.|[=*+\/\-] |.[=*+\/\-]))((?<![0-9A-Za-z_=*+\-\/.])(?P<value>[0-9]{16})(?![0-9A-Za-z_=*+\-\/.]))(?!(\.[0-9]| [=*+\/\-]|.[=*+\/\-]))
+  filter_type: CreditCardNumberSequence
+  use_ml: false
+  validations: []
+  min_line_len: 16
+
 - name: API
   severity: medium
   type: keyword

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,14 +1,14 @@
 from pathlib import Path
 
 # total number of files in test samples, included .gitignore
-SAMPLES_FILES_COUNT: int = 66
+SAMPLES_FILES_COUNT: int = 67
 
 # credentials count after scan
-SAMPLES_CRED_COUNT: int = 64
-SAMPLES_CRED_LINE_COUNT: int = 68
+SAMPLES_CRED_COUNT: int = 65
+SAMPLES_CRED_LINE_COUNT: int = 69
 
 # credentials count after post-processing
-SAMPLES_POST_CRED_COUNT: int = 32
+SAMPLES_POST_CRED_COUNT: int = 33
 
 # archived credentials that not found without --depth
 SAMPLES_IN_DEEP_1 = 7

--- a/tests/filters/test_credit_card_number_check.py
+++ b/tests/filters/test_credit_card_number_check.py
@@ -1,0 +1,41 @@
+import pytest
+
+from credsweeper.filters.cred_card_number_check import CreditCardNumberCheck
+from tests.test_utils.dummy_line_data import get_line_data
+
+
+class TestCreditCardNumberCheck:
+
+    # https://www.paypalobjects.com/en_AU/vhelp/paypalmanager_help/credit_card_numbers.htm
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "0378282246310005",  # American Express
+            "5555555555554444",  # MasterCard
+            "4111111111111111",  # Visa with correct last digit
+        ])
+    def test_credit_card_number_check_p(self, file_path: pytest.fixture, line: str) -> None:
+        cred_candidate = get_line_data(file_path=file_path, line=line, pattern=r"(?P<value>.*$)")
+        assert CreditCardNumberCheck().run(cred_candidate) is False
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "",  # empty line
+            "0000000000000000",  # zero variant
+            "12345678901234567",  # 17 digits
+            "378282246310005",  # American Express in 15 digits
+            "abcdefghijklmnop",  # ValueError
+            "4111111111111110",  # Visa with wrong last digit
+            "4111111111111112",
+            "4111111111111113",
+            "4111111111111114",
+            "4111111111111115",
+            "4111111111111116",
+            "4111111111111117",
+            "4111111111111118",
+            "4111111111111119",
+        ])
+    def test_credit_card_number_check_n(self, file_path: pytest.fixture, line: str) -> None:
+        cred_candidate = get_line_data(file_path=file_path, line=line, pattern=r"(?P<value>.*$)")
+        assert CreditCardNumberCheck().run(cred_candidate) is True

--- a/tests/samples/credit_card_numbers
+++ b/tests/samples/credit_card_numbers
@@ -1,0 +1,3 @@
+0000000000000000 valid number sequence for card number, but filtered
+4012888888881881 test number from https://www.paypalobjects.com/en_AU/vhelp/paypalmanager_help/credit_card_numbers.htm
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -566,3 +566,23 @@ class TestMain:
         files_provider = [TextContentProvider(file_path) for file_path in files]
         cred_sweeper.scan(files_provider)
         assert len(cred_sweeper.credential_manager.get_credentials()) == 1
+
+    # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+    def test_credit_card_number_p(self) -> None:
+        content_provider: FilesProvider = TextProvider([SAMPLES_DIR / "credit_card_numbers"])
+        cred_sweeper = CredSweeper()
+        cred_sweeper.run(content_provider=content_provider)
+        found_credentials = cred_sweeper.credential_manager.get_credentials()
+        assert len(found_credentials) == 1
+
+    # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+    def test_credit_card_number_n(self) -> None:
+        with tempfile.NamedTemporaryFile("w") as tmp:
+            tmp.write("0000000000000000\n9999999999999999\n")  # zero and wrong sequence
+            tmp.flush()
+            content_provider: FilesProvider = TextProvider([tmp.name])
+            cred_sweeper = CredSweeper()
+            cred_sweeper.run(content_provider=content_provider)
+            assert len(cred_sweeper.credential_manager.get_credentials()) == 0


### PR DESCRIPTION
## Description

- Added rule to find credit card number in number sequnce
- Added filter to check the number sequence with Luhn algorithm

Probably necessary to apply https://github.com/Samsung/CredData/pull/22 first - then update the scores

## How has this been tested?

- [x] UnitTest
- [x] Benchmark finds the real  credentials
