### PR TITLE
Shopify token rule updated

### DIFF
--- a/credsweeper/rules/config.yaml
+++ b/credsweeper/rules/config.yaml
@@ -340,9 +340,9 @@
   severity: high
   type: pattern
   values:
-    - (?P<value>(shpat|shpca|shppa|shpss)_[a-fA-F0-9]{32})
-  filter_type: GeneralPattern
-  use_ml: true
+    - (?P<value>shp(at|ca|pa|ss)_[a-fA-F0-9]{32})
+  filter_type: TokenPattern
+  use_ml: false
   validations: []
   required_substrings:
     - shp

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,7 +8,7 @@ SAMPLES_CRED_COUNT: int = 75
 SAMPLES_CRED_LINE_COUNT: int = 79
 
 # credentials count after post-processing
-SAMPLES_POST_CRED_COUNT: int = 55
+SAMPLES_POST_CRED_COUNT: int = 56
 
 # archived credentials that not found without --depth
 SAMPLES_IN_DEEP_1 = 15

--- a/tests/data/depth_9.json
+++ b/tests/data/depth_9.json
@@ -1072,6 +1072,24 @@
     },
     {
         "api_validation": "NOT_AVAILABLE",
+        "ml_validation": "NOT_AVAILABLE",
+        "ml_probability": null,
+        "rule": "Shopify Token",
+        "severity": "high",
+        "line_data_list": [
+            {
+                "line": "    \"shopyfy_k\": \"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\",",
+                "line_num": 1,
+                "path": "tests/samples/shopify_token",
+                "info": "tests/samples/shopify_token|RAW",
+                "value": "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",
+                "variable": null,
+                "entropy_validation": true
+            }
+        ]
+    },
+    {
+        "api_validation": "NOT_AVAILABLE",
         "ml_validation": "VALIDATED_KEY",
         "ml_probability": 0.89421,
         "rule": "Slack Token",

--- a/tests/data/doc.json
+++ b/tests/data/doc.json
@@ -424,6 +424,24 @@
     },
     {
         "api_validation": "NOT_AVAILABLE",
+        "ml_validation": "NOT_AVAILABLE",
+        "ml_probability": null,
+        "rule": "Shopify Token",
+        "severity": "high",
+        "line_data_list": [
+            {
+                "line": "    \"shopyfy_k\": \"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\",",
+                "line_num": 1,
+                "path": "tests/samples/shopify_token",
+                "info": "tests/samples/shopify_token|RAW",
+                "value": "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",
+                "variable": null,
+                "entropy_validation": true
+            }
+        ]
+    },
+    {
+        "api_validation": "NOT_AVAILABLE",
         "ml_validation": "VALIDATED_KEY",
         "ml_probability": 0.89421,
         "rule": "Slack Token",

--- a/tests/data/output.json
+++ b/tests/data/output.json
@@ -784,6 +784,24 @@
     },
     {
         "api_validation": "NOT_AVAILABLE",
+        "ml_validation": "NOT_AVAILABLE",
+        "ml_probability": null,
+        "rule": "Shopify Token",
+        "severity": "high",
+        "line_data_list": [
+            {
+                "line": "    \"shopyfy_k\": \"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\",",
+                "line_num": 1,
+                "path": "tests/samples/shopify_token",
+                "info": "",
+                "value": "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",
+                "variable": null,
+                "entropy_validation": true
+            }
+        ]
+    },
+    {
+        "api_validation": "NOT_AVAILABLE",
         "ml_validation": "VALIDATED_KEY",
         "ml_probability": 0.89421,
         "rule": "Slack Token",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -582,7 +582,7 @@ class TestApp(TestCase):
             rules_set = set([i["name"] for i in rules])
             missed = {  #
                 'AWS MWS Key', 'Facebook Access Token', 'Google Multi', 'Instagram Access Token', 'MailChimp API Key',
-                'PayPal Braintree Access Token', 'Picatic API Key', 'SendGrid API Key', 'Shopify Token'
+                'PayPal Braintree Access Token', 'Picatic API Key', 'SendGrid API Key'
             }
             self.assertSetEqual(rules_set.difference(missed), report_set, f"\n{_stdout}")
             self.assertEqual(SAMPLES_POST_CRED_COUNT, len(report))


### PR DESCRIPTION
## Description

- Update Shopify token rule with disabled ml because it has strong prefix signature and ML is overhead for this

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] UnitTest - the rule exists in report
- [x] Benchmark
