### PR TITLE
reduced html is parsed too with additional line ending for <p>

### DIFF
--- a/credsweeper/file_handler/data_content_provider.py
+++ b/credsweeper/file_handler/data_content_provider.py
@@ -148,15 +148,18 @@ class DataContentProvider(ContentProvider):
         try:
             text = self.data.decode(encoding=DEFAULT_ENCODING)
             html = None
-            for tag in ["</html>", "</body>", "</head>", "</div>", "</table>"]:
-                if tag in text:
-                    html = BeautifulSoup(text, features="html.parser")
-                    break
+            if "</" in text and ">" in text:
+                html = BeautifulSoup(text, features="html.parser")
             if html:
                 # simple parse as it is displayed to user
-                for line_number, line in enumerate(html.text.splitlines()):
-                    if line and line.strip():
-                        self.line_numbers.append(line_number)
+                # dbg = html.find_all(text=True)
+                for p in html.find_all("p"):
+                    p.append('\n')
+                lines = html.get_text().splitlines()
+                for line_number, doc_line in enumerate(lines):
+                    line = doc_line.strip()
+                    if line:
+                        self.line_numbers.append(line_number + 1)
                         self.lines.append(line)
 
                 # transform table if table cell is assigned to header cell

--- a/tests/data/depth_9.json
+++ b/tests/data/depth_9.json
@@ -1060,10 +1060,10 @@
         "severity": "medium",
         "line_data_list": [
             {
-                "line": "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}t : password = Xdj@jcN834b.",
-                "line_num": 1,
+                "line": "password = Xdj@jcN834b.",
+                "line_num": 2,
                 "path": "tests/samples/password.docx",
-                "info": "tests/samples/password.docx|ZIP|word/document.xml|XML",
+                "info": "tests/samples/password.docx|ZIP|word/document.xml|HTML",
                 "value": "Xdj@jcN834b.",
                 "variable": "password",
                 "entropy_validation": false
@@ -1727,7 +1727,7 @@
         "line_data_list": [
             {
                 "line": "508627689:AAEuLPKs-EhrjrYGnz60bnYNZqakf6HJxc0",
-                "line_num": 63,
+                "line_num": 64,
                 "path": "tests/samples/test.html",
                 "info": "tests/samples/test.html|HTML",
                 "value": "508627689:AAEuLPKs-EhrjrYGnz60bnYNZqakf6HJxc0",

--- a/tests/data/doc.json
+++ b/tests/data/doc.json
@@ -953,7 +953,7 @@
         "line_data_list": [
             {
                 "line": "508627689:AAEuLPKs-EhrjrYGnz60bnYNZqakf6HJxc0",
-                "line_num": 63,
+                "line_num": 64,
                 "path": "tests/samples/test.html",
                 "info": "tests/samples/test.html|HTML",
                 "value": "508627689:AAEuLPKs-EhrjrYGnz60bnYNZqakf6HJxc0",


### PR DESCRIPTION
## Description

- reduced html text without <header>, <body> might be parsed too
- add line end for <p> tags to split values

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] UnitTest
