### PR TITLE
Add lower_path to check_exclude_file() for exclude exact file path

### DIFF
--- a/credsweeper/file_handler/file_path_extractor.py
+++ b/credsweeper/file_handler/file_path_extractor.py
@@ -137,7 +137,7 @@ class FilePathExtractor:
         for exclude_path in config.exclude_paths:
             if exclude_path in path:
                 return True
-        file_extension = Util.get_extension(path, lower=False)
+        file_extension = Util.get_extension(path)
         if file_extension in config.exclude_extensions:
             return True
         if not config.depth and file_extension in config.exclude_containers:

--- a/credsweeper/file_handler/file_path_extractor.py
+++ b/credsweeper/file_handler/file_path_extractor.py
@@ -127,11 +127,12 @@ class FilePathExtractor:
         Return:
             True when the file full path should be excluded according config
         """
-        path = path.replace('\\', '/').lower()
-        if config.not_allowed_path_pattern.match(path):
+        path = path.replace('\\', '/')
+        lower_path = path.lower()
+        if config.not_allowed_path_pattern.match(lower_path):
             return True
         for exclude_pattern in config.exclude_patterns:
-            if exclude_pattern.match(path):
+            if exclude_pattern.match(lower_path):
                 return True
         for exclude_path in config.exclude_paths:
             if exclude_path in path:

--- a/tests/file_handler/test_file_path_extractor.py
+++ b/tests/file_handler/test_file_path_extractor.py
@@ -55,7 +55,6 @@ class TestFilePathExtractor:
         "dummy.JPG",
         "/tmp/target/dummy.p12",
         "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmptjz2p1zk\\target\\dummy.p12",
-        "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmptjz2p1zk\\tArGet\\dummy.p12",
     ])
     def test_check_exclude_file_n(self, config: Config, file_path: pytest.fixture) -> None:
         config.find_by_ext = True


### PR DESCRIPTION
## Description

`FilePathExtractor.check_exclude_file()` method has a bug before.
The method just convert a `path` to lower case, so when checking the exclude file path, it didn't work properly.

I fixed this bug with adding `lower_path` parameter to `check_exclude_file()`.
`check_exclude_file()` uses `lower_path` on pattern matching and uses `path` on excluding exact paths and extensions.

- Fix bug of `check_exclude_file()`

## How has this been tested?

- [X] Local tested
