### PR TITLE
Remove URL Credentials rule from doc option

### DIFF
--- a/credsweeper/rules/config.yaml
+++ b/credsweeper/rules/config.yaml
@@ -391,6 +391,7 @@
   required_substrings:
     - //
   min_line_len: 10
+  doc_available: false
 
 - name: Auth
   severity: medium

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,7 +11,7 @@ SAMPLES_CRED_LINE_COUNT: int = 114
 SAMPLES_POST_CRED_COUNT: int = 97
 
 # with option --doc
-SAMPLES_IN_DOC = 87
+SAMPLES_IN_DOC = 86
 
 # archived credentials that are not found without --depth
 SAMPLES_IN_DEEP_1 = SAMPLES_POST_CRED_COUNT + 17

--- a/tests/data/doc.json
+++ b/tests/data/doc.json
@@ -1993,28 +1993,6 @@
     {
         "api_validation": "NOT_AVAILABLE",
         "ml_validation": "VALIDATED_KEY",
-        "ml_probability": 0.99672,
-        "rule": "URL Credentials",
-        "severity": "high",
-        "line_data_list": [
-            {
-                "line": "url: mongodb://jrfdeg:dh3sjr8b@prod-best-sec.example.com:32768/architecture",
-                "line_num": 1,
-                "path": "tests/samples/url.groovy",
-                "info": "tests/samples/url.groovy|RAW",
-                "value": "dh3sjr8b",
-                "variable": null,
-                "entropy_validation": {
-                    "iterator": "BASE64_CHARS",
-                    "entropy": 3.0,
-                    "valid": false
-                }
-            }
-        ]
-    },
-    {
-        "api_validation": "NOT_AVAILABLE",
-        "ml_validation": "VALIDATED_KEY",
         "ml_probability": 0.95248,
         "rule": "Password",
         "severity": "medium",


### PR DESCRIPTION
## Description

I've checked the results from `--doc` option internally and there are a lot of FPs with `URL Credentials` rule.
So remove `URL Credentials` rule from `--doc` option.

- Remove `URL Credentials` rule from `--doc` option

## How has this been tested?

- [X] Local tested
