### PR TITLE
Add version range to bs4 package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r", encoding="utf8") as fh:
     long_description = fh.read()
 
 install_requires = [
-    "beautifulsoup4",  #
+    "beautifulsoup4>=4.12.2",  #
     "GitPython",  #
     "google_auth_oauthlib",  #
     "humanfriendly",  #

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r", encoding="utf8") as fh:
     long_description = fh.read()
 
 install_requires = [
-    "beautifulsoup4>=4.12.2",  #
+    "beautifulsoup4>=4.11.0",  # the lowest version with XMLParsedAsHTMLWarning
     "GitPython",  #
     "google_auth_oauthlib",  #
     "humanfriendly",  #


### PR DESCRIPTION
## Description

There was an error when I trying to use CredSweeper v1.5.6 with bs4 package which version under 4.12.2.
``` bash
ImportError: cannot import name 'XMLParsedAsHTMLWarning' from 'bs4' (/usr/lib/python3/dist-packages/bs4/__init__.py)
```

So I added version ragne to `setup.py` to avoid this error.

- Fix bs4 require version error

## How has this been tested?

- [X] UnitTest
- [X] Benchmark
