### PR TITLE
remove scikit-learn from release installation

### DIFF
--- a/credsweeper/ml_model/features.py
+++ b/credsweeper/ml_model/features.py
@@ -233,7 +233,7 @@ class RenyiEntropy(Feature):
             # corresponds to Shannon entropy
             entropy = np.sum(-p_x * np.log2(p_x))
         else:
-            entropy = np.log2((p_x ** self.alpha).sum()) / (1.0 - self.alpha)
+            entropy = np.log2((p_x**self.alpha).sum()) / (1.0 - self.alpha)
 
         return entropy
 

--- a/credsweeper/ml_model/features.py
+++ b/credsweeper/ml_model/features.py
@@ -4,8 +4,6 @@ from abc import ABC, abstractmethod
 from typing import List, Any, Dict
 
 import numpy as np
-from scipy.sparse import csr_matrix
-from sklearn.preprocessing import LabelBinarizer
 
 from credsweeper.common.constants import Base, Chars, CHUNK_SIZE
 from credsweeper.credentials import Candidate
@@ -18,14 +16,14 @@ class Feature(ABC):
     def __init__(self):
         self.__words: List[str] = []  # type: ignore
 
-    def __call__(self, candidates: List[Candidate]) -> List[bool]:
+    def __call__(self, candidates: List[Candidate]) -> np.ndarray:
         """Call base class for features.
 
         Args:
             candidates: list of candidates to extract features
 
         """
-        return [self.extract(candidate) for candidate in candidates]
+        return np.array([self.extract(candidate) for candidate in candidates])
 
     @abstractmethod
     def extract(self, candidate: Candidate) -> Any:
@@ -235,7 +233,7 @@ class RenyiEntropy(Feature):
             # corresponds to Shannon entropy
             entropy = np.sum(-p_x * np.log2(p_x))
         else:
-            entropy = np.log2((p_x**self.alpha).sum()) / (1.0 - self.alpha)
+            entropy = np.log2((p_x ** self.alpha).sum()) / (1.0 - self.alpha)
 
         return entropy
 
@@ -298,13 +296,18 @@ class FileExtension(Feature):
 
     def __init__(self, extensions: List[str]) -> None:
         super().__init__()
-        self.label_binarizer = LabelBinarizer()
-        self.label_binarizer.fit(extensions)
+        self.__dimension = len(extensions)
+        self.__extension_sorted_list = sorted(list(set(extensions)))
+        if len(self.__extension_sorted_list) != self.__dimension:
+            raise RuntimeError(f"Check duplicates:{extensions}")
 
-    def __call__(self, candidates: List[Candidate]) -> csr_matrix:
-        extensions = [candidate.line_data_list[0].file_type for candidate in candidates]
-        result = self.label_binarizer.transform(extensions)
-        return result
+    def __call__(self, candidates: List[Candidate]) -> np.ndarray:
+        extension_set = set([candidate.line_data_list[0].file_type for candidate in candidates])
+        result = np.zeros(shape=[self.__dimension], dtype=np.float32)
+        for i, extension in enumerate(self.__extension_sorted_list):
+            if extension in extension_set:
+                result[i] = 1.0
+        return np.array([result])
 
     def extract(self, candidate: Candidate) -> Any:
         raise NotImplementedError
@@ -320,13 +323,18 @@ class RuleName(Feature):
 
     def __init__(self, rule_names: List[str]) -> None:
         super().__init__()
-        self.label_binarizer = LabelBinarizer()
-        self.label_binarizer.fit(rule_names)
+        self.__dimension = len(rule_names)
+        self.__rule_name_sorted_list = sorted(list(set(rule_names)))
+        if len(self.__rule_name_sorted_list) != self.__dimension:
+            raise RuntimeError(f"Check duplicates:{rule_names}")
 
-    def __call__(self, candidates: List[Candidate]) -> csr_matrix:
-        rule_names = [candidate.rule_name for candidate in candidates]
-        result = self.label_binarizer.transform(rule_names)
-        return result
+    def __call__(self, candidates: List[Candidate]) -> np.ndarray:
+        result = np.zeros(shape=[self.__dimension], dtype=np.int8)
+        candidate_rule_set = set(x.rule_name for x in candidates)
+        for i, rule in enumerate(self.__rule_name_sorted_list):
+            if rule in candidate_rule_set:
+                result[i] = 1
+        return np.array([result])
 
     def extract(self, candidate: Candidate) -> Any:
         raise NotImplementedError

--- a/experiment/requirements.txt
+++ b/experiment/requirements.txt
@@ -9,4 +9,7 @@ wrapt==1.14.1
 matplotlib
 tensorrt
 
+# scikit-learn 1.5.0 may not support python 3.8
+scikit-learn
+
 types-tensorflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "python-docx",
     "PyYAML",
     "requests",
-    "scikit-learn",
     "scipy",
     "typing_extensions",
     "whatthepatch",

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,6 @@ base58==2.1.1
 numpy==1.24.4
 # ^ the version supports python 3.8-3.11
 # ^ todo: check for py3.12 later https://github.com/numpy/numpy/issues/23808
-scikit-learn==1.3.2
 scipy==1.10.1
 # ^ the version supports python 3.8
 onnxruntime==1.18.0


### PR DESCRIPTION
## Description

Please include a summary of the change and which is fixed.

- remove scikit-learn from sources
- migrated to custom binarization - no slowdown, even speedup 2~3%
- add scikit-learn in experiment (ML train requirements)
- partially fixes #568 

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] UnitTest
- [x] Benchmark
