### PR TITLE
Thrifty memory consumption

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Run CredSweeper tool
         run: |
-          credsweeper --banner --log info --jobs $(nproc) --sort --subtext --path data --save-json report.${{ github.event.pull_request.head.sha }}.json | tee credsweeper.${{ github.event.pull_request.head.sha }}.log
+          credsweeper --banner --log info --jobs $(nproc) --thrifty --sort --subtext --path data --save-json report.${{ github.event.pull_request.head.sha }}.json | tee credsweeper.${{ github.event.pull_request.head.sha }}.log
 
       - name: Run Benchmark
         run: |

--- a/credsweeper/__main__.py
+++ b/credsweeper/__main__.py
@@ -203,6 +203,10 @@ def get_arguments() -> Namespace:
                         dest="jobs",
                         default=1,
                         metavar="POSITIVE_INT")
+    parser.add_argument("--thrifty",
+                        help="clear objects after scan to reduce memory consumption",
+                        action="store_const",
+                        const=True)
     parser.add_argument("--skip_ignored",
                         help="parse .gitignore files and skip credentials from ignored objects",
                         dest="skip_ignored",
@@ -295,6 +299,7 @@ def scan(args: Namespace, content_provider: AbstractProvider) -> int:
                                   size_limit=args.size_limit,
                                   exclude_lines=denylist,
                                   exclude_values=denylist,
+                                  thrifty=args.thrifty,
                                   log_level=args.log)
         return credsweeper.run(content_provider=content_provider)
     except Exception as exc:

--- a/credsweeper/file_handler/byte_content_provider.py
+++ b/credsweeper/file_handler/byte_content_provider.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 from typing import List, Optional, Generator
 
 from credsweeper.file_handler.analysis_target import AnalysisTarget
@@ -20,30 +21,29 @@ class ByteContentProvider(ContentProvider):
 
         """
         super().__init__(file_path=file_path, file_type=file_type, info=info)
-        self.data = content
+        self.__data = content
         self.__lines: Optional[List[str]] = None
 
-    @property
+    @cached_property
     def data(self) -> Optional[bytes]:
-        """data getter for ByteContentProvider"""
+        """data RO getter for ByteContentProvider"""
         return self.__data
 
-    @data.setter
-    def data(self, data: Optional[bytes]) -> None:
-        """data setter for ByteContentProvider"""
-        self.__data = data
+    def free(self) -> None:
+        """free data after scan to reduce memory usage"""
+        self.__data = None
+        if hasattr(self, "data"):
+            delattr(self, "data")
+        self.__lines = None
+        if hasattr(self, "lines"):
+            delattr(self, "lines")
 
-    @property
+    @cached_property
     def lines(self) -> List[str]:
-        """lines getter for ByteContentProvider"""
+        """lines RO getter for ByteContentProvider"""
         if self.__lines is None:
             self.__lines = Util.decode_bytes(self.__data)
         return self.__lines if self.__lines is not None else []
-
-    @lines.setter
-    def lines(self, lines: List[str]) -> None:
-        """lines setter for ByteContentProvider"""
-        self.__lines = lines
 
     def yield_analysis_target(self, min_len: int) -> Generator[AnalysisTarget, None, None]:
         """Return lines to scan.

--- a/credsweeper/file_handler/content_provider.py
+++ b/credsweeper/file_handler/content_provider.py
@@ -64,16 +64,15 @@ class ContentProvider(ABC):
         """info getter"""
         return self.__descriptor.info
 
-    @property
+    @cached_property
     @abstractmethod
     def data(self) -> Optional[bytes]:
         """abstract data getter"""
         raise NotImplementedError(__name__)
 
-    @data.setter
     @abstractmethod
-    def data(self, data: Optional[bytes]) -> None:
-        """abstract data setter"""
+    def free(self) -> None:
+        """free data after scan to reduce memory usage"""
         raise NotImplementedError(__name__)
 
     def lines_to_targets(

--- a/credsweeper/file_handler/data_content_provider.py
+++ b/credsweeper/file_handler/data_content_provider.py
@@ -2,6 +2,7 @@ import json
 import logging
 import string
 import warnings
+from functools import cached_property
 from typing import List, Optional, Any, Generator, Callable, Tuple
 
 import yaml
@@ -37,30 +38,41 @@ class DataContentProvider(ContentProvider):
 
         """
         super().__init__(file_path=file_path, file_type=file_type, info=info)
-        self.__inited_text: str = ""
-        self.data = data
+        self.__data = data
+        self.__text: Optional[str] = None
         self.structure: Optional[List[Any]] = None
         self.decoded: Optional[bytes] = None
         self.lines: List[str] = []
         self.line_numbers: List[int] = []
         self.__html_lines_size = len(data)  # the size is used to limit extra memory consumption during html combination
 
-    @property
+    @cached_property
     def data(self) -> Optional[bytes]:
-        """data getter for DataContentProvider"""
+        """data RO getter for DataContentProvider and the property is used in deep scan"""
         return self.__data
 
-    @data.setter
-    def data(self, data: Optional[bytes]) -> None:
-        """data setter for DataContentProvider"""
-        self.__data = data
+    def free(self) -> None:
+        """free data after scan to reduce memory usage"""
+        self.__data = None
+        if hasattr(self, "data"):
+            delattr(self, "data")
+        self.__text = None
+        if hasattr(self, "text"):
+            delattr(self, "text")
+        self.structure = None
+        self.decoded = None
+        self.lines = []
+        self.line_numbers = []
 
-    @property
-    def __text(self) -> str:
-        """Getter which throws exception in case of bad decoding"""
-        if not self.__inited_text:
-            self.__inited_text = self.data.decode(encoding=DEFAULT_ENCODING, errors="strict")
-        return self.__inited_text
+    @cached_property
+    def text(self) -> str:
+        """Getter to produce a text from DEFAULT_ENCODING. Empty str for unrecognized data"""
+        if self.__text is None:
+            try:
+                self.__text = self.__data.decode(encoding=DEFAULT_ENCODING, errors="strict")
+            except Exception:
+                self.__text = ''
+        return self.__text
 
     def __is_structure(self) -> bool:
         """Check whether a structure was recognized"""
@@ -71,15 +83,12 @@ class DataContentProvider(ContentProvider):
         """Tries to convert data with many parsers. Stores result to internal structure
         Return True if some structure found
         """
-        try:
-            if MIN_DATA_LEN > len(self.__text):
-                return False
-        except Exception:
+        if MIN_DATA_LEN > len(self.text):
             return False
         # JSON & NDJSON
-        if "{" in self.__text and "}" in self.__text and "\"" in self.__text and ":" in self.__text:
+        if "{" in self.text and "}" in self.text and "\"" in self.text and ":" in self.text:
             try:
-                self.structure = json.loads(self.__text)
+                self.structure = json.loads(self.text)
                 logger.debug("CONVERTED from json")
             except Exception as exc:
                 logger.debug("Cannot parse as json:%s %s", exc, self.data)
@@ -88,7 +97,7 @@ class DataContentProvider(ContentProvider):
                     return True
             try:
                 self.structure = []
-                for line in self.__text.splitlines():
+                for line in self.text.splitlines():
                     # each line must be in json format, otherwise - exception rises
                     self.structure.append(json.loads(line))
                 logger.debug("CONVERTED from ndjson")
@@ -104,8 +113,8 @@ class DataContentProvider(ContentProvider):
         # # # Python
         try:
             # search only in sources with strings
-            if (";" in self.__text or 2 < self.__text.count("\n")) and ("\"" in self.__text or "'" in self.__text):
-                self.structure = Util.parse_python(self.__text)
+            if (";" in self.text or 2 < self.text.count("\n")) and ("\"" in self.text or "'" in self.text):
+                self.structure = Util.parse_python(self.text)
                 logger.debug("CONVERTED from Python")
             else:
                 logger.debug("Data do not contain line feed - weak PYTHON")
@@ -116,8 +125,8 @@ class DataContentProvider(ContentProvider):
                 return True
         # # # YAML - almost always recognized
         try:
-            if ":" in self.__text and 2 < self.__text.count("\n"):
-                self.structure = yaml.load(self.__text, Loader=yaml.FullLoader)
+            if ":" in self.text and 2 < self.text.count("\n"):
+                self.structure = yaml.load(self.text, Loader=yaml.FullLoader)
                 logger.debug("CONVERTED from yaml")
             else:
                 logger.debug("Data do not contain colon mark - weak YAML")
@@ -136,11 +145,11 @@ class DataContentProvider(ContentProvider):
              True if reading was successful
 
         """
-        if MIN_XML_LEN > len(self.data):
+        if MIN_XML_LEN > len(self.text):
             return False
         try:
-            if "<" in self.__text and ">" in self.__text and "</" in self.__text:
-                xml_text = self.__text.splitlines()
+            if "<" in self.text and ">" in self.text and "</" in self.text:
+                xml_text = self.text.splitlines()
                 self.lines, self.line_numbers = Util.get_xml_from_lines(xml_text)
                 logger.debug("CONVERTED from xml")
             else:

--- a/credsweeper/file_handler/diff_content_provider.py
+++ b/credsweeper/file_handler/diff_content_provider.py
@@ -1,4 +1,5 @@
 import logging
+from functools import cached_property
 from typing import List, Tuple, Generator
 
 from credsweeper.common.constants import DiffRowType
@@ -32,26 +33,34 @@ class DiffContentProvider(ContentProvider):
             change_type: DiffRowType,  #
             diff: List[DiffDict]) -> None:
         super().__init__(file_path=file_path, info=f"{file_path}:{change_type.value}")
-        self.change_type = change_type
-        self.diff = diff
+        self.__change_type = change_type
+        self.__diff = diff
 
-    @property
+    @cached_property
     def data(self) -> bytes:
         """data getter for DiffContentProvider"""
         raise NotImplementedError(__name__)
 
-    @data.setter
-    def data(self, data: bytes) -> None:
-        """data setter for DiffContentProvider"""
-        raise NotImplementedError(__name__)
+    @cached_property
+    def diff(self) -> List[DiffDict]:
+        """diff getter for DiffContentProvider"""
+        return self.__diff
 
-    def parse_lines_data(self, lines_data: List[DiffRowData]) -> Tuple[List[int], List[str]]:
+    def free(self) -> None:
+        """free data after scan to reduce memory usage"""
+        self.__diff = None
+        if hasattr(self, "diff"):
+            delattr(self, "diff")
+
+    @staticmethod
+    def parse_lines_data(change_type: DiffRowType, lines_data: List[DiffRowData]) -> Tuple[List[int], List[str]]:
         """Parse diff lines data.
 
         Return list of line numbers with change type "self.change_type" and list of all lines in file
             in original order(replaced all lines not mentioned in diff file with blank line)
 
         Args:
+            change_type: set added or deleted file data to scan
             lines_data: data of all rows mentioned in diff file
 
         Return:
@@ -62,7 +71,7 @@ class DiffContentProvider(ContentProvider):
         change_numbs = []
         all_lines = []
         for line_data in lines_data:
-            if line_data.line_type == self.change_type:
+            if line_data.line_type == change_type:
                 change_numbs.append(line_data.line_numb)
                 all_lines.append(line_data.line)
         return change_numbs, all_lines
@@ -77,6 +86,6 @@ class DiffContentProvider(ContentProvider):
             list of analysis targets of every row of file diff corresponding to change type "self.change_type"
 
         """
-        lines_data = Util.preprocess_file_diff(self.diff)
-        change_numbs, all_lines = self.parse_lines_data(lines_data)
+        lines_data = Util.preprocess_file_diff(self.__diff)
+        change_numbs, all_lines = self.parse_lines_data(self.__change_type, lines_data)
         return self.lines_to_targets(min_len, all_lines, change_numbs)

--- a/credsweeper/file_handler/struct_content_provider.py
+++ b/credsweeper/file_handler/struct_content_provider.py
@@ -1,4 +1,5 @@
 import logging
+from functools import cached_property
 from typing import Optional, Any, Generator
 
 from credsweeper.file_handler.analysis_target import AnalysisTarget
@@ -22,27 +23,23 @@ class StructContentProvider(ContentProvider):
 
         """
         super().__init__(file_path=file_path, file_type=file_type, info=info)
-        self.struct = struct
-
-    @property
-    def struct(self) -> Any:
-        """obj getter"""
-        return self.__struct
-
-    @struct.setter
-    def struct(self, struct: Any) -> None:
-        """obj setter"""
         self.__struct = struct
 
-    @property
+    @cached_property
     def data(self) -> bytes:
         """data getter for StructContentProvider"""
         raise NotImplementedError(__name__)
 
-    @data.setter
-    def data(self, data: bytes) -> None:
-        """data setter for StructContentProvider"""
-        raise NotImplementedError(__name__)
+    @cached_property
+    def struct(self) -> Any:
+        """struct getter for StructContentProvider"""
+        return self.__struct
+
+    def free(self) -> None:
+        """free data after scan to reduce memory usage"""
+        self.__struct = None
+        if hasattr(self, "struct"):
+            delattr(self, "struct")
 
     def yield_analysis_target(self, min_len: int) -> Generator[AnalysisTarget, None, None]:
         """Return nothing. The class provides only data storage.

--- a/credsweeper/utils/util.py
+++ b/credsweeper/utils/util.py
@@ -229,7 +229,7 @@ class Util:
                     # LATIN_1 may convert data (bytes in range 0x80:0xFF are transformed)
                     # so skip this encoding when checking binaries
                     logger.warning("Binary file detected")
-                    return []
+                    break
                 text = content.decode(encoding, errors="strict")
                 if content != text.encode(encoding, errors="strict"):
                     raise UnicodeError

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -17,7 +17,7 @@ Get all argument list:
                              [--rules PATH] [--severity SEVERITY] [--config PATH] [--log_config PATH] [--denylist PATH]
                              [--find-by-ext] [--depth POSITIVE_INT] [--no-filters] [--doc] [--ml_threshold FLOAT_OR_STR]
                              [--ml_batch_size POSITIVE_INT] [--ml_config PATH] [--ml_model PATH] [--ml_providers STR]
-                             [--jobs POSITIVE_INT] [--skip_ignored] [--save-json [PATH]]
+                             [--jobs POSITIVE_INT] [--thrifty] [--skip_ignored] [--save-json [PATH]]
                              [--save-xlsx [PATH]] [--color] [--hashed] [--subtext] [--sort] [--log LOG_LEVEL]
                              [--size_limit SIZE_LIMIT]
                              [--banner] [--version]
@@ -50,6 +50,7 @@ Get all argument list:
       --ml_providers STR    comma separated list of providers for onnx (CPUExecutionProvider is used by default)
       --jobs POSITIVE_INT, -j POSITIVE_INT
                             number of parallel processes to use (default: 1)
+      --thrifty             clear objects after scan to reduce memory consumption
       --skip_ignored        parse .gitignore files and skip credentials from ignored objects
       --save-json [PATH]    save result to json file (default: output.json)
       --save-xlsx [PATH]    save result to xlsx file (default: output.xlsx)

--- a/fuzz/coveraging.sh
+++ b/fuzz/coveraging.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #set -x
 set -e

--- a/fuzz/fuzzing.sh
+++ b/fuzz/fuzzing.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #set -x
 set -e

--- a/fuzz/minimizing.sh
+++ b/fuzz/minimizing.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #set -x
 set -e

--- a/fuzz/minimizing.sh
+++ b/fuzz/minimizing.sh
@@ -13,13 +13,13 @@ cp -vf fuzz/__main__.py .minimizing.py
 CORPUS_DIR=fuzz/corpus
 MINIMIZING_DIR=fuzz/.corpus.minimizing
 
-rm -vrf ${MINIMIZING_DIR}
+rm -vfr ${MINIMIZING_DIR}
 
 mkdir -vp ${MINIMIZING_DIR}
 
 # ## freeze original coverage
 
-rm -rf ${MINIMIZING_DIR}/htmlcov
+rm -fr ${MINIMIZING_DIR}/htmlcov
 
 rm -vf .coverage
 

--- a/fuzz/re-fuzzing.sh
+++ b/fuzz/re-fuzzing.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #set -x
 set -e
@@ -99,9 +99,7 @@ for x in $(seq 0 15); do
     j=$(printf "%01x" ${x})
     TARGETDIR=${THISDIR}/${j}
     for f in $(find ${TARGETDIR}/${CORPUS_DIR} -type f); do mv -vf ${f} ${PARENTDIR}/${CORPUS_DIR}/; done
-    # dbg
-    cat ${TARGETDIR}/fuzz/nohup.out
-    rm -vfr ${TARGETDIR}
+    rm -fr ${TARGETDIR}
 done
 
 # last minimization

--- a/fuzz/re-fuzzing.sh
+++ b/fuzz/re-fuzzing.sh
@@ -51,6 +51,9 @@ for n in $(seq 0 15); do
     mkdir -vp ${TARGETDIR}/fuzz/corpus
     cp -r ${PARENTDIR}/credsweeper ${TARGETDIR}/
     cp -v ${PARENTDIR}/.coveragerc ${TARGETDIR}/
+    # import NEGLIGIBLE_ML_THRESHOLD from tests ONLY
+    mkdir -vp ${TARGETDIR}/tests
+    grep NEGLIGIBLE_ML_THRESHOLD ${PARENTDIR}/tests/__init__.py | tee ${TARGETDIR}/tests/__init__.py
     cp -v ${PARENTDIR}/fuzz/__main__.py ${TARGETDIR}/fuzz/
     cp -v ${PARENTDIR}/fuzz/minimizing.sh ${TARGETDIR}/fuzz/
     for f in $(find ${PARENTDIR}/${CORPUS_DIR} -type f -name "${j}*"); do mv -vf ${f} ${TARGETDIR}/${CORPUS_DIR}/; done
@@ -96,7 +99,9 @@ for x in $(seq 0 15); do
     j=$(printf "%01x" ${x})
     TARGETDIR=${THISDIR}/${j}
     for f in $(find ${TARGETDIR}/${CORPUS_DIR} -type f); do mv -vf ${f} ${PARENTDIR}/${CORPUS_DIR}/; done
-    rm -rf ${TARGETDIR}
+    # dbg
+    cat ${TARGETDIR}/fuzz/nohup.out
+    rm -vfr ${TARGETDIR}
 done
 
 # last minimization

--- a/fuzz/reducing.sh
+++ b/fuzz/reducing.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #set -x
 set -e

--- a/fuzz/reducing.sh
+++ b/fuzz/reducing.sh
@@ -49,7 +49,7 @@ while [ $uniq_corpus_size -ne $full_corpus_size ] || [ $uniq_corpus_count -ne $f
         exit 1;
     fi
 
-    rm -vrf ${REDUCING_DIR}
+    rm -vfr ${REDUCING_DIR}
     mkdir -vp ${REDUCING_DIR}
     mv -vf ${CORPUS_DIR}/* ${REDUCING_DIR}/
 
@@ -77,7 +77,7 @@ while [ $uniq_corpus_size -ne $full_corpus_size ] || [ $uniq_corpus_count -ne $f
 done
 
 if [ $uniq_corpus_size -eq $full_corpus_size ] && [ $uniq_corpus_count -eq $full_corpus_count ]; then
-    rm -vrf .reducing.py ${REDUCING_DIR}
+    rm -vfr .reducing.py ${REDUCING_DIR}
 fi
 
 SPENT_TIME=$(date -ud "@$(( $(date +%s) - ${START_TIME} ))" +"%H:%M:%S")

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -5,21 +5,29 @@ from tests import SAMPLES_POST_CRED_COUNT, SAMPLES_IN_DEEP_3, SAMPLES_CRED_COUNT
 
 DATA_TEST_CFG: List[Dict[str, Any]] = [{
     "__cred_count": SAMPLES_CRED_COUNT,
+    "pool_count": 1,
+    "thrifty": True,
     "sort_output": True,
     "json_filename": "ml_threshold.json",
     "ml_threshold": NEGLIGIBLE_ML_THRESHOLD
 }, {
     "__cred_count": SAMPLES_POST_CRED_COUNT,
+    "pool_count": 2,
+    "thrifty": False,
     "sort_output": True,
     "json_filename": "output.json"
 }, {
     "__cred_count": SAMPLES_IN_DOC,
+    "pool_count": 1,
+    "thrifty": False,
     "sort_output": True,
     "subtext": True,
     "json_filename": "doc.json",
     "doc": True
 }, {
     "__cred_count": SAMPLES_IN_DEEP_3,
+    "pool_count": 2,
+    "thrifty": True,
     "sort_output": True,
     "json_filename": "depth_3.json",
     "depth": 3

--- a/tests/file_handler/test_byte_content_provider.py
+++ b/tests/file_handler/test_byte_content_provider.py
@@ -6,7 +6,7 @@ import pytest
 from credsweeper.file_handler.analysis_target import AnalysisTarget
 from credsweeper.file_handler.byte_content_provider import ByteContentProvider
 from credsweeper.utils import Util
-from tests import SAMPLES_FILES_COUNT, SAMPLES_PATH
+from tests import SAMPLES_FILES_COUNT, SAMPLES_PATH, AZ_DATA
 from tests.filters.conftest import DUMMY_DESCRIPTOR
 
 
@@ -39,3 +39,8 @@ class TestByteContentProvider:
                 provider = ByteContentProvider(bin_data)
                 assert util_text == provider.lines
         assert files_counter == SAMPLES_FILES_COUNT
+
+    def test_free_n(self) -> None:
+        provider = ByteContentProvider(AZ_DATA)
+        provider.free()
+        assert provider.data is None

--- a/tests/file_handler/test_data_content_provider.py
+++ b/tests/file_handler/test_data_content_provider.py
@@ -182,3 +182,8 @@ class DataContentProviderTest(unittest.TestCase):
         content_provider = DataContentProvider(zb2, "zip_bomb_2")
         res_2 = cs.deep_scanner.recursive_scan(content_provider, 16, 1 << 16)
         self.assertEqual(0, len(res_2))
+
+    def test_free_n(self) -> None:
+        provider = DataContentProvider(AZ_DATA)
+        provider.free()
+        self.assertIsNone(provider.data)

--- a/tests/file_handler/test_diff_content_provider.py
+++ b/tests/file_handler/test_diff_content_provider.py
@@ -100,3 +100,7 @@ class TestDiffContentProvider(unittest.TestCase):
         provider = DiffContentProvider("file_path", DiffRowType.ADDED, diff)
         provider.free()
         self.assertIsNone(provider.diff)
+
+    def test_data_n(self) -> None:
+        with self.assertRaises(NotImplementedError):
+            _ = DiffContentProvider("file_path", DiffRowType.ADDED, []).data

--- a/tests/file_handler/test_diff_content_provider.py
+++ b/tests/file_handler/test_diff_content_provider.py
@@ -81,3 +81,22 @@ class TestDiffContentProvider(unittest.TestCase):
         expected_numbs = []
 
         self.assertListEqual(expected_numbs, change_numbs)
+
+    def test_free_n(self) -> None:
+        diff = [
+            DiffDict({
+                "old": 2,
+                "new": None,
+                "line": "new line",
+                "hunk": 1
+            }),
+            DiffDict({
+                "old": 3,
+                "new": None,
+                "line": "moved line",
+                "hunk": 1
+            })
+        ]
+        provider = DiffContentProvider("file_path", DiffRowType.ADDED, diff)
+        provider.free()
+        self.assertIsNone(provider.diff)

--- a/tests/file_handler/test_diff_content_provider.py
+++ b/tests/file_handler/test_diff_content_provider.py
@@ -64,13 +64,9 @@ class TestDiffContentProvider(unittest.TestCase):
 
     def test_parse_lines_data_p(self) -> None:
         """Evaluate that added diff lines data correctly added to change_numbers"""
-        file_path = "dumy.file"
-        diff = []
-        content_provider = DiffContentProvider(file_path, DiffRowType.ADDED, diff)
-
         lines_data = [DiffRowData(DiffRowType.ADDED, 2, "new line")]
 
-        change_numbs, _all_lines = content_provider.parse_lines_data(lines_data)
+        change_numbs, _all_lines = DiffContentProvider.parse_lines_data(DiffRowType.ADDED, lines_data)
 
         expected_numbs = [2]
 
@@ -78,13 +74,9 @@ class TestDiffContentProvider(unittest.TestCase):
 
     def test_parse_lines_data_n(self) -> None:
         """Evaluate that deleted diff lines data correctly filtered for added change type"""
-        file_path = "dumy.file"
-        diff = []
-        content_provider = DiffContentProvider(file_path, DiffRowType.ADDED, diff)
-
         lines_data = [DiffRowData(DiffRowType.DELETED, 2, "old line")]
 
-        change_numbs, _all_lines = content_provider.parse_lines_data(lines_data)
+        change_numbs, _all_lines = DiffContentProvider.parse_lines_data(DiffRowType.ADDED, lines_data)
 
         expected_numbs = []
 

--- a/tests/file_handler/test_string_content_provider.py
+++ b/tests/file_handler/test_string_content_provider.py
@@ -54,3 +54,7 @@ class TestStringContentProvider(unittest.TestCase):
         provider = StringContentProvider([AZ_STRING])
         provider.free()
         self.assertListEqual([], provider.lines)
+
+    def test_data_n(self) -> None:
+        with self.assertRaises(NotImplementedError):
+            _ = StringContentProvider([AZ_STRING]).data

--- a/tests/file_handler/test_string_content_provider.py
+++ b/tests/file_handler/test_string_content_provider.py
@@ -2,6 +2,7 @@ import unittest
 
 from credsweeper.file_handler.analysis_target import AnalysisTarget
 from credsweeper.file_handler.string_content_provider import StringContentProvider
+from tests import AZ_STRING
 from tests.filters.conftest import DUMMY_DESCRIPTOR
 
 
@@ -48,3 +49,8 @@ class TestStringContentProvider(unittest.TestCase):
         self.assertEqual(1, analysis_targets[0].line_num)
         self.assertEqual(2, analysis_targets[1].line_num)
         self.assertEqual(3, analysis_targets[2].line_num)
+
+    def test_free_n(self) -> None:
+        provider = StringContentProvider([AZ_STRING])
+        provider.free()
+        self.assertListEqual([], provider.lines)

--- a/tests/file_handler/test_struct_content_provider.py
+++ b/tests/file_handler/test_struct_content_provider.py
@@ -1,0 +1,20 @@
+import unittest
+
+from credsweeper.common.constants import DiffRowType
+from credsweeper.file_handler.analysis_target import AnalysisTarget
+from credsweeper.file_handler.descriptor import Descriptor
+from credsweeper.file_handler.diff_content_provider import DiffContentProvider
+from credsweeper.file_handler.struct_content_provider import StructContentProvider
+from credsweeper.utils import DiffRowData, DiffDict
+
+
+class TestStructContentProvider(unittest.TestCase):
+
+    def test_free_n(self) -> None:
+        provider = StructContentProvider({})
+        provider.free()
+        self.assertIsNone(provider.struct)
+
+    def test_data_n(self) -> None:
+        with self.assertRaises(NotImplementedError):
+            _ = StructContentProvider({}).data

--- a/tests/file_handler/test_text_content_provider.py
+++ b/tests/file_handler/test_text_content_provider.py
@@ -62,3 +62,8 @@ class TestTextContentProvider(unittest.TestCase):
 
             target = analysis_targets[0]
             self.assertEqual(expected_target.line, target.line)
+
+    def test_free_n(self) -> None:
+        provider = TextContentProvider("dummy")
+        provider.free()
+        self.assertListEqual([], provider.lines)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -221,6 +221,7 @@ class TestApp(TestCase):
                    " [--ml_model PATH]" \
                    " [--ml_providers STR] " \
                    " [--jobs POSITIVE_INT]" \
+                   " [--thrifty]" \
                    " [--skip_ignored]" \
                    " [--save-json [PATH]]" \
                    " [--save-xlsx [PATH]]" \


### PR DESCRIPTION
## Description

Please include a summary of the change and which is fixed.

- Add --thrifty agrument to cleanup unnecessary data after scan to prevent extra memory consumption. IO descriptors are closed also.
- Re-fuzzed with the argument

Before --thrifty (v1.10.4):
```
Detected Credentials: 11731
Time Elapsed: 376.4159982204437s
    Command being timed: ".venv/bin/python -m credsweeper --sort --path data --subtext --save-json -j 4 --log info"
    User time (seconds): 1420.57
    System time (seconds): 5.15
    Percent of CPU this job got: 377%
    Elapsed (wall clock) time (h:mm:ss or m:ss): 6:17.30
    Average shared text size (kbytes): 0
    Average unshared data size (kbytes): 0
    Average stack size (kbytes): 0
    Average total size (kbytes): 0
    Maximum resident set size (kbytes): 1077604
    Average resident set size (kbytes): 0
    Major (requiring I/O) page faults: 443
    Minor (reclaiming a frame) page faults: 1248323
    Voluntary context switches: 5113
    Involuntary context switches: 1032859
    Swaps: 0
    File system inputs: 172456
    File system outputs: 33208
    Socket messages sent: 0
    Socket messages received: 0
    Signals delivered: 0
    Page size (bytes): 4096
    Exit status: 0
```
with --thrifty 
```
Detected Credentials: 11731
Time Elapsed: 372.83459281921387s
    Command being timed: ".venv/bin/python -m credsweeper --sort --path data --subtext --save-json -j 4 --log info --thrifty"
    User time (seconds): 1385.45
    System time (seconds): 4.66
    Percent of CPU this job got: 372%
    Elapsed (wall clock) time (h:mm:ss or m:ss): 6:13.45
    Average shared text size (kbytes): 0
    Average unshared data size (kbytes): 0
    Average stack size (kbytes): 0
    Average total size (kbytes): 0
    Maximum resident set size (kbytes): 387708
    Average resident set size (kbytes): 0
    Major (requiring I/O) page faults: 6
    Minor (reclaiming a frame) page faults: 633933
    Voluntary context switches: 19608
    Involuntary context switches: 1067122
    Swaps: 0
    File system inputs: 2003152
    File system outputs: 33256
    Socket messages sent: 0
    Socket messages received: 0
    Signals delivered: 0
    Page size (bytes): 4096
    Exit status: 0
```


## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] UnitTest
- [x] Benchmark
