### PR TITLE
Prevent extra line split for HTML scan

### DIFF
--- a/credsweeper/deep_scanner/mxfile_scanner.py
+++ b/credsweeper/deep_scanner/mxfile_scanner.py
@@ -5,7 +5,6 @@ from typing import List, Optional
 from bs4 import BeautifulSoup
 from lxml import etree
 
-from credsweeper.common.constants import UTF_8
 from credsweeper.credentials import Candidate
 from credsweeper.deep_scanner.abstract_scanner import AbstractScanner
 from credsweeper.file_handler.data_content_provider import DataContentProvider
@@ -26,7 +25,7 @@ class MxfileScanner(AbstractScanner, ABC):
         try:
             lines = []
             line_numbers = []
-            tree = etree.fromstring(data_provider.data.decode(UTF_8))
+            tree = etree.fromstring(data_provider.text)
             for element in tree.iter():
                 if "mxCell" == getattr(element, "tag"):
                     line_number = element.sourceline

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 
 # total number of files in test samples
-SAMPLES_FILES_COUNT = 146
+SAMPLES_FILES_COUNT = 147
 
 # the lowest value of ML threshold is used to display possible lowest values
 NEGLIGIBLE_ML_THRESHOLD = 0.0001
 
 # credentials count after scan with negligible ML threshold
-SAMPLES_CRED_COUNT = 465
+SAMPLES_CRED_COUNT = 470
 SAMPLES_CRED_LINE_COUNT = SAMPLES_CRED_COUNT + 19
 
 # Number of filtered credentials with ML
@@ -17,16 +17,17 @@ ML_FILTERED = 91
 SAMPLES_POST_CRED_COUNT = SAMPLES_CRED_COUNT - ML_FILTERED
 
 # with option --doc
-SAMPLES_IN_DOC = 650
+SAMPLES_IN_DOC = 656
 
 # archived credentials that are not found without --depth
-SAMPLES_IN_DEEP_1 = SAMPLES_POST_CRED_COUNT + 84
+SAMPLES_IN_DEEP_1 = SAMPLES_POST_CRED_COUNT + 87
 SAMPLES_IN_DEEP_2 = SAMPLES_IN_DEEP_1 + 8
 SAMPLES_IN_DEEP_3 = SAMPLES_IN_DEEP_2 + 1
 
 # well known string with all latin letters
 AZ_DATA = b"The quick brown fox jumps over the lazy dog"
-AZ_STRING = AZ_DATA.decode(encoding="ascii")
+# Assume, there should be only ASCII symbols
+AZ_STRING = AZ_DATA.decode(encoding="ascii", errors="strict")
 
 # tests directory - use ONLY this file relevance for "release_test" workflow
 TESTS_PATH = Path(__file__).resolve().parent

--- a/tests/data/depth_3.json
+++ b/tests/data/depth_3.json
@@ -5103,44 +5103,19 @@
         ]
     },
     {
-        "rule": "Password",
-        "severity": "medium",
-        "confidence": "moderate",
-        "ml_probability": 0.996,
-        "line_data_list": [
-            {
-                "line": "Password: \"Dw7^&nd<dj\"",
-                "line_num": 13,
-                "path": "./tests/samples/drawio",
-                "info": "FILE|MXFILE",
-                "value": "Dw7^&nd<dj",
-                "value_start": 11,
-                "value_end": 21,
-                "variable": "Password",
-                "variable_start": 0,
-                "variable_end": 8,
-                "entropy_validation": {
-                    "iterator": "BASE64STDPAD_CHARS",
-                    "entropy": 2.1253496664211537,
-                    "valid": false
-                }
-            }
-        ]
-    },
-    {
         "rule": "UUID",
         "severity": "info",
         "confidence": "strong",
         "ml_probability": null,
         "line_data_list": [
             {
-                "line": "token is bace4d19-fa7e-b2e4-1afe-9129474bcd81",
+                "line": "password is NsIdksKJdj\ttoken is bace4d19-fa7e-b2e4-1afe-9129474bcd81\tPassword: \"Dw7^&nd<dj\"",
                 "line_num": 13,
                 "path": "./tests/samples/drawio",
                 "info": "FILE|MXFILE",
                 "value": "bace4d19-fa7e-b2e4-1afe-9129474bcd81",
-                "value_start": 9,
-                "value_end": 45,
+                "value_start": 32,
+                "value_end": 68,
                 "variable": null,
                 "variable_start": -2,
                 "variable_end": -2,
@@ -8999,6 +8974,206 @@
         ]
     },
     {
+        "rule": "UUID",
+        "severity": "info",
+        "confidence": "strong",
+        "ml_probability": null,
+        "line_data_list": [
+            {
+                "line": "Print, crumple, throw away. line # 10 a0572bc9-7a3e-beef-cafe-9129474bcd81",
+                "line_num": 10,
+                "path": "./tests/samples/pretty.html",
+                "info": "FILE|HTML",
+                "value": "a0572bc9-7a3e-beef-cafe-9129474bcd81",
+                "value_start": 38,
+                "value_end": 74,
+                "variable": null,
+                "variable_start": -2,
+                "variable_end": -2,
+                "entropy_validation": {
+                    "iterator": "BASE36_CHARS",
+                    "entropy": 3.4906434037593512,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
+        "rule": "Token",
+        "severity": "medium",
+        "confidence": "moderate",
+        "ml_probability": 1.0,
+        "line_data_list": [
+            {
+                "line": "http://localhost:8888/v1/api/get?token=zUkITxodk63bDVUMwIymb3zKTxICz85zC00cv0Geline80",
+                "line_num": 80,
+                "path": "./tests/samples/pretty.html",
+                "info": "FILE|HTML",
+                "value": "zUkITxodk63bDVUMwIymb3zKTxICz85zC00cv0Geline80",
+                "value_start": 39,
+                "value_end": 85,
+                "variable": "token",
+                "variable_start": 33,
+                "variable_end": 38,
+                "entropy_validation": {
+                    "iterator": "BASE64STDPAD_CHARS",
+                    "entropy": 4.681064401662153,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
+        "rule": "Token",
+        "severity": "medium",
+        "confidence": "moderate",
+        "ml_probability": 1.0,
+        "line_data_list": [
+            {
+                "line": "http://localhost:8888/v1/api/get?token=zUkITxodk63bDVUMwIymb3zKTxICz85zC00cv0Geline80",
+                "line_num": 80,
+                "path": "./tests/samples/pretty.html",
+                "info": "FILE|HTML",
+                "value": "zUkITxodk63bDVUMwIymb3zKTxICz85zC00cv0Geline80",
+                "value_start": 39,
+                "value_end": 85,
+                "variable": "token",
+                "variable_start": 33,
+                "variable_end": 38,
+                "entropy_validation": {
+                    "iterator": "BASE64STDPAD_CHARS",
+                    "entropy": 4.681064401662153,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
+        "rule": "Password",
+        "severity": "medium",
+        "confidence": "moderate",
+        "ml_probability": 0.987,
+        "line_data_list": [
+            {
+                "line": "id/pass : user/Jid8^5gvB",
+                "line_num": 133,
+                "path": "./tests/samples/pretty.html",
+                "info": "FILE|HTML",
+                "value": "user/Jid8^5gvB",
+                "value_start": 10,
+                "value_end": 24,
+                "variable": "pass",
+                "variable_start": 3,
+                "variable_end": 7,
+                "entropy_validation": {
+                    "iterator": "BASE64STDPAD_CHARS",
+                    "entropy": 3.5354009990534907,
+                    "valid": false
+                }
+            }
+        ]
+    },
+    {
+        "rule": "Password",
+        "severity": "medium",
+        "confidence": "moderate",
+        "ml_probability": 1.0,
+        "line_data_list": [
+            {
+                "line": "147# password: Jd3OnNy^564eD5_sd",
+                "line_num": 147,
+                "path": "./tests/samples/pretty.html",
+                "info": "FILE|HTML",
+                "value": "Jd3OnNy^564eD5_sd",
+                "value_start": 15,
+                "value_end": 32,
+                "variable": "password",
+                "variable_start": 5,
+                "variable_end": 13,
+                "entropy_validation": {
+                    "iterator": "BASE64STDPAD_CHARS",
+                    "entropy": 3.371290742279712,
+                    "valid": false
+                }
+            }
+        ]
+    },
+    {
+        "rule": "Password",
+        "severity": "medium",
+        "confidence": "moderate",
+        "ml_probability": 1.0,
+        "line_data_list": [
+            {
+                "line": "147# password: Jd3OnNy^564eD5_sd",
+                "line_num": 147,
+                "path": "./tests/samples/pretty.html",
+                "info": "FILE|HTML",
+                "value": "Jd3OnNy^564eD5_sd",
+                "value_start": 15,
+                "value_end": 32,
+                "variable": "password",
+                "variable_start": 5,
+                "variable_end": 13,
+                "entropy_validation": {
+                    "iterator": "BASE64STDPAD_CHARS",
+                    "entropy": 3.371290742279712,
+                    "valid": false
+                }
+            }
+        ]
+    },
+    {
+        "rule": "UUID",
+        "severity": "info",
+        "confidence": "strong",
+        "ml_probability": null,
+        "line_data_list": [
+            {
+                "line": "151# a0ce4d19-7a3e-beef-cafe-9129474bcd81",
+                "line_num": 151,
+                "path": "./tests/samples/pretty.html",
+                "info": "FILE|HTML",
+                "value": "a0ce4d19-7a3e-beef-cafe-9129474bcd81",
+                "value_start": 5,
+                "value_end": 41,
+                "variable": null,
+                "variable_start": -2,
+                "variable_end": -2,
+                "entropy_validation": {
+                    "iterator": "BASE36_CHARS",
+                    "entropy": 3.3903756128027736,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
+        "rule": "UUID",
+        "severity": "info",
+        "confidence": "strong",
+        "ml_probability": null,
+        "line_data_list": [
+            {
+                "line": "151# a0ce4d19-7a3e-beef-cafe-9129474bcd81",
+                "line_num": 151,
+                "path": "./tests/samples/pretty.html",
+                "info": "FILE|HTML",
+                "value": "a0ce4d19-7a3e-beef-cafe-9129474bcd81",
+                "value_start": 5,
+                "value_end": 41,
+                "variable": null,
+                "variable_start": -2,
+                "variable_end": -2,
+                "entropy_validation": {
+                    "iterator": "BASE36_CHARS",
+                    "entropy": 3.3903756128027736,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
         "rule": "PyPi API Token",
         "severity": "high",
         "confidence": "strong",
@@ -12131,7 +12306,7 @@
         "line_data_list": [
             {
                 "line": "508627689:AAEuLPKs-EhrjrYGnz60bnYNZqakf6HJxc0",
-                "line_num": 83,
+                "line_num": 76,
                 "path": "./tests/samples/test.html",
                 "info": "FILE|HTML",
                 "value": "508627689:AAEuLPKs-EhrjrYGnz60bnYNZqakf6HJxc0",
@@ -12143,6 +12318,56 @@
                 "entropy_validation": {
                     "iterator": "BASE64STDPAD_CHARS",
                     "entropy": 4.697662125333612,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
+        "rule": "Google OAuth Access Token",
+        "severity": "high",
+        "confidence": "moderate",
+        "ml_probability": null,
+        "line_data_list": [
+            {
+                "line": "# 94 ya29.dshMb48ehfXwydAj34D32J",
+                "line_num": 83,
+                "path": "./tests/samples/test.html",
+                "info": "FILE|HTML",
+                "value": "ya29.dshMb48ehfXwydAj34D32J",
+                "value_start": 5,
+                "value_end": 32,
+                "variable": null,
+                "variable_start": -2,
+                "variable_end": -2,
+                "entropy_validation": {
+                    "iterator": "BASE36_CHARS",
+                    "entropy": 3.2538013905715872,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
+        "rule": "Digital Ocean Token",
+        "severity": "high",
+        "confidence": "strong",
+        "ml_probability": null,
+        "line_data_list": [
+            {
+                "line": "# 95 dop_v1_425522a565f532bc6532d453422e50334a42f5242a3090fbe553b543b124259b",
+                "line_num": 84,
+                "path": "./tests/samples/test.html",
+                "info": "FILE|HTML",
+                "value": "dop_v1_425522a565f532bc6532d453422e50334a42f5242a3090fbe553b543b124259b",
+                "value_start": 5,
+                "value_end": 76,
+                "variable": null,
+                "variable_start": -2,
+                "variable_end": -2,
+                "entropy_validation": {
+                    "iterator": "BASE36_CHARS",
+                    "entropy": 3.5117321397240535,
                     "valid": true
                 }
             }
@@ -12181,43 +12406,43 @@
         "line_data_list": [
             {
                 "line": "# 95 dop_v1_425522a565f532bc6532d453422e50334a42f5242a3090fbe553b543b124259b",
+                "line_num": 87,
+                "path": "./tests/samples/test.html",
+                "info": "FILE|HTML",
+                "value": "dop_v1_425522a565f532bc6532d453422e50334a42f5242a3090fbe553b543b124259b",
+                "value_start": 5,
+                "value_end": 76,
+                "variable": null,
+                "variable_start": -2,
+                "variable_end": -2,
+                "entropy_validation": {
+                    "iterator": "BASE36_CHARS",
+                    "entropy": 3.5117321397240535,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
+        "rule": "Facebook Access Token",
+        "severity": "high",
+        "confidence": "moderate",
+        "ml_probability": null,
+        "line_data_list": [
+            {
+                "line": "the line will be found twice # 100 EAACEb00Kse0BAlGy7KeQ5YnaCEd09Eose0cBAlGy7KeQ5Yna9CoDsup39tiYdoQ4jH9Coup39tiYdWoQ4jHFZD",
                 "line_num": 89,
                 "path": "./tests/samples/test.html",
                 "info": "FILE|HTML",
-                "value": "dop_v1_425522a565f532bc6532d453422e50334a42f5242a3090fbe553b543b124259b",
-                "value_start": 5,
-                "value_end": 76,
+                "value": "EAACEb00Kse0BAlGy7KeQ5YnaCEd09Eose0cBAlGy7KeQ5Yna9CoDsup39tiYdoQ4jH9Coup39tiYdWoQ4jHFZD",
+                "value_start": 35,
+                "value_end": 122,
                 "variable": null,
                 "variable_start": -2,
                 "variable_end": -2,
                 "entropy_validation": {
-                    "iterator": "BASE36_CHARS",
-                    "entropy": 3.5117321397240535,
-                    "valid": true
-                }
-            }
-        ]
-    },
-    {
-        "rule": "Google OAuth Access Token",
-        "severity": "high",
-        "confidence": "moderate",
-        "ml_probability": null,
-        "line_data_list": [
-            {
-                "line": "# 94 ya29.dshMb48ehfXwydAj34D32J",
-                "line_num": 91,
-                "path": "./tests/samples/test.html",
-                "info": "FILE|HTML",
-                "value": "ya29.dshMb48ehfXwydAj34D32J",
-                "value_start": 5,
-                "value_end": 32,
-                "variable": null,
-                "variable_start": -2,
-                "variable_end": -2,
-                "entropy_validation": {
-                    "iterator": "BASE36_CHARS",
-                    "entropy": 3.2538013905715872,
+                    "iterator": "BASE64STDPAD_CHARS",
+                    "entropy": 4.936120692057913,
                     "valid": true
                 }
             }
@@ -12249,51 +12474,26 @@
         ]
     },
     {
-        "rule": "Digital Ocean Token",
-        "severity": "high",
-        "confidence": "strong",
-        "ml_probability": null,
+        "rule": "SQL Password",
+        "severity": "medium",
+        "confidence": "weak",
+        "ml_probability": 1.0,
         "line_data_list": [
             {
-                "line": "# 95 dop_v1_425522a565f532bc6532d453422e50334a42f5242a3090fbe553b543b124259b",
-                "line_num": 94,
+                "line": "ALTER\tUSER\tdetector\tIDENTIFIED\tBY\tSqLpa5sW0rD4;",
+                "line_num": 110,
                 "path": "./tests/samples/test.html",
                 "info": "FILE|HTML",
-                "value": "dop_v1_425522a565f532bc6532d453422e50334a42f5242a3090fbe553b543b124259b",
-                "value_start": 5,
-                "value_end": 76,
-                "variable": null,
-                "variable_start": -2,
-                "variable_end": -2,
-                "entropy_validation": {
-                    "iterator": "BASE36_CHARS",
-                    "entropy": 3.5117321397240535,
-                    "valid": true
-                }
-            }
-        ]
-    },
-    {
-        "rule": "Facebook Access Token",
-        "severity": "high",
-        "confidence": "moderate",
-        "ml_probability": null,
-        "line_data_list": [
-            {
-                "line": "the line will be found twice # 100 EAACEb00Kse0BAlGy7KeQ5YnaCEd09Eose0cBAlGy7KeQ5Yna9CoDsup39tiYdoQ4jH9Coup39tiYdWoQ4jHFZD",
-                "line_num": 101,
-                "path": "./tests/samples/test.html",
-                "info": "FILE|HTML",
-                "value": "EAACEb00Kse0BAlGy7KeQ5YnaCEd09Eose0cBAlGy7KeQ5Yna9CoDsup39tiYdoQ4jH9Coup39tiYdWoQ4jHFZD",
-                "value_start": 35,
-                "value_end": 122,
-                "variable": null,
-                "variable_start": -2,
-                "variable_end": -2,
+                "value": "SqLpa5sW0rD4",
+                "value_start": 34,
+                "value_end": 46,
+                "variable": "ALTER\tUSER\tdetector\tIDENTIFIED\tBY",
+                "variable_start": 0,
+                "variable_end": 33,
                 "entropy_validation": {
                     "iterator": "BASE64STDPAD_CHARS",
-                    "entropy": 4.936120692057913,
-                    "valid": true
+                    "entropy": 3.584962500721156,
+                    "valid": false
                 }
             }
         ]

--- a/tests/data/doc.json
+++ b/tests/data/doc.json
@@ -12578,35 +12578,10 @@
         "rule": "DOC_CREDENTIALS",
         "severity": "medium",
         "confidence": "weak",
-        "ml_probability": 0.847,
+        "ml_probability": 0.95,
         "line_data_list": [
             {
-                "line": "Password: \"Dw7^&nd<dj\"",
-                "line_num": 13,
-                "path": "./tests/samples/drawio",
-                "info": "FILE|MXFILE",
-                "value": "Dw7^&nd<dj",
-                "value_start": 11,
-                "value_end": 21,
-                "variable": "Password",
-                "variable_start": 0,
-                "variable_end": 8,
-                "entropy_validation": {
-                    "iterator": "BASE64STDPAD_CHARS",
-                    "entropy": 2.1253496664211537,
-                    "valid": false
-                }
-            }
-        ]
-    },
-    {
-        "rule": "DOC_CREDENTIALS",
-        "severity": "medium",
-        "confidence": "weak",
-        "ml_probability": 0.992,
-        "line_data_list": [
-            {
-                "line": "password is NsIdksKJdj",
+                "line": "password is NsIdksKJdj\ttoken is bace4d19-fa7e-b2e4-1afe-9129474bcd81\tPassword: \"Dw7^&nd<dj\"",
                 "line_num": 13,
                 "path": "./tests/samples/drawio",
                 "info": "FILE|MXFILE",
@@ -12631,13 +12606,13 @@
         "ml_probability": null,
         "line_data_list": [
             {
-                "line": "token is bace4d19-fa7e-b2e4-1afe-9129474bcd81",
+                "line": "password is NsIdksKJdj\ttoken is bace4d19-fa7e-b2e4-1afe-9129474bcd81\tPassword: \"Dw7^&nd<dj\"",
                 "line_num": 13,
                 "path": "./tests/samples/drawio",
                 "info": "FILE|MXFILE",
                 "value": "bace4d19-fa7e-b2e4-1afe-9129474bcd81",
-                "value_start": 9,
-                "value_end": 45,
+                "value_start": 32,
+                "value_end": 68,
                 "variable": null,
                 "variable_start": -2,
                 "variable_end": -2,
@@ -12653,19 +12628,19 @@
         "rule": "DOC_CREDENTIALS",
         "severity": "medium",
         "confidence": "weak",
-        "ml_probability": 0.993,
+        "ml_probability": 0.997,
         "line_data_list": [
             {
-                "line": "token is bace4d19-fa7e-b2e4-1afe-9129474bcd81",
+                "line": "password is NsIdksKJdj\ttoken is bace4d19-fa7e-b2e4-1afe-9129474bcd81\tPassword: \"Dw7^&nd<dj\"",
                 "line_num": 13,
                 "path": "./tests/samples/drawio",
                 "info": "FILE|MXFILE",
                 "value": "bace4d19-fa7e-b2e4-1afe-9129474bcd81",
-                "value_start": 9,
-                "value_end": 45,
+                "value_start": 32,
+                "value_end": 68,
                 "variable": "token",
-                "variable_start": 0,
-                "variable_end": 5,
+                "variable_start": 23,
+                "variable_end": 28,
                 "entropy_validation": {
                     "iterator": "BASE36_CHARS",
                     "entropy": 3.254803820546211,
@@ -15430,6 +15405,156 @@
         ]
     },
     {
+        "rule": "UUID",
+        "severity": "info",
+        "confidence": "strong",
+        "ml_probability": null,
+        "line_data_list": [
+            {
+                "line": "Print, crumple, throw away. line # 10 a0572bc9-7a3e-beef-cafe-9129474bcd81",
+                "line_num": 10,
+                "path": "./tests/samples/pretty.html",
+                "info": "FILE|HTML",
+                "value": "a0572bc9-7a3e-beef-cafe-9129474bcd81",
+                "value_start": 38,
+                "value_end": 74,
+                "variable": null,
+                "variable_start": -2,
+                "variable_end": -2,
+                "entropy_validation": {
+                    "iterator": "BASE36_CHARS",
+                    "entropy": 3.4906434037593512,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
+        "rule": "DOC_CREDENTIALS",
+        "severity": "medium",
+        "confidence": "weak",
+        "ml_probability": 1.0,
+        "line_data_list": [
+            {
+                "line": "http://localhost:8888/v1/api/get?token=zUkITxodk63bDVUMwIymb3zKTxICz85zC00cv0Geline80",
+                "line_num": 80,
+                "path": "./tests/samples/pretty.html",
+                "info": "FILE|HTML",
+                "value": "zUkITxodk63bDVUMwIymb3zKTxICz85zC00cv0Geline80",
+                "value_start": 39,
+                "value_end": 85,
+                "variable": "token",
+                "variable_start": 33,
+                "variable_end": 38,
+                "entropy_validation": {
+                    "iterator": "BASE64STDPAD_CHARS",
+                    "entropy": 4.681064401662153,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
+        "rule": "SECRET_PAIR",
+        "severity": "medium",
+        "confidence": "moderate",
+        "ml_probability": null,
+        "line_data_list": [
+            {
+                "line": "http://localhost:8888/v1/api/get?token=zUkITxodk63bDVUMwIymb3zKTxICz85zC00cv0Geline80",
+                "line_num": 80,
+                "path": "./tests/samples/pretty.html",
+                "info": "FILE|HTML",
+                "value": "zUkITxodk63bDVUMwIymb3zKTxICz85zC00cv0Geline80",
+                "value_start": 39,
+                "value_end": 85,
+                "variable": "token",
+                "variable_start": 33,
+                "variable_end": 38,
+                "entropy_validation": {
+                    "iterator": "BASE64STDPAD_CHARS",
+                    "entropy": 4.681064401662153,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
+        "rule": "DOC_CREDENTIALS",
+        "severity": "medium",
+        "confidence": "weak",
+        "ml_probability": 1.0,
+        "line_data_list": [
+            {
+                "line": "147# password: Jd3OnNy^564eD5_sd",
+                "line_num": 147,
+                "path": "./tests/samples/pretty.html",
+                "info": "FILE|HTML",
+                "value": "Jd3OnNy^564eD5_sd",
+                "value_start": 15,
+                "value_end": 32,
+                "variable": "password",
+                "variable_start": 5,
+                "variable_end": 13,
+                "entropy_validation": {
+                    "iterator": "BASE64STDPAD_CHARS",
+                    "entropy": 3.371290742279712,
+                    "valid": false
+                }
+            }
+        ]
+    },
+    {
+        "rule": "PASSWD_PAIR",
+        "severity": "medium",
+        "confidence": "moderate",
+        "ml_probability": null,
+        "line_data_list": [
+            {
+                "line": "147# password: Jd3OnNy^564eD5_sd",
+                "line_num": 147,
+                "path": "./tests/samples/pretty.html",
+                "info": "FILE|HTML",
+                "value": "Jd3OnNy^564eD5_sd",
+                "value_start": 15,
+                "value_end": 32,
+                "variable": "password",
+                "variable_start": 5,
+                "variable_end": 13,
+                "entropy_validation": {
+                    "iterator": "BASE64STDPAD_CHARS",
+                    "entropy": 3.371290742279712,
+                    "valid": false
+                }
+            }
+        ]
+    },
+    {
+        "rule": "UUID",
+        "severity": "info",
+        "confidence": "strong",
+        "ml_probability": null,
+        "line_data_list": [
+            {
+                "line": "151# a0ce4d19-7a3e-beef-cafe-9129474bcd81",
+                "line_num": 151,
+                "path": "./tests/samples/pretty.html",
+                "info": "FILE|HTML",
+                "value": "a0ce4d19-7a3e-beef-cafe-9129474bcd81",
+                "value_start": 5,
+                "value_end": 41,
+                "variable": null,
+                "variable_start": -2,
+                "variable_end": -2,
+                "entropy_validation": {
+                    "iterator": "BASE36_CHARS",
+                    "entropy": 3.3903756128027736,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
         "rule": "PyPi API Token",
         "severity": "high",
         "confidence": "strong",
@@ -17755,7 +17880,7 @@
         "line_data_list": [
             {
                 "line": "508627689:AAEuLPKs-EhrjrYGnz60bnYNZqakf6HJxc0",
-                "line_num": 83,
+                "line_num": 76,
                 "path": "./tests/samples/test.html",
                 "info": "FILE|HTML",
                 "value": "508627689:AAEuLPKs-EhrjrYGnz60bnYNZqakf6HJxc0",
@@ -17780,7 +17905,7 @@
         "line_data_list": [
             {
                 "line": "# 94 ya29.dshMb48ehfXwydAj34D32J",
-                "line_num": 91,
+                "line_num": 83,
                 "path": "./tests/samples/test.html",
                 "info": "FILE|HTML",
                 "value": "ya29.dshMb48ehfXwydAj34D32J",
@@ -17805,7 +17930,7 @@
         "line_data_list": [
             {
                 "line": "# 95 dop_v1_425522a565f532bc6532d453422e50334a42f5242a3090fbe553b543b124259b",
-                "line_num": 94,
+                "line_num": 84,
                 "path": "./tests/samples/test.html",
                 "info": "FILE|HTML",
                 "value": "dop_v1_425522a565f532bc6532d453422e50334a42f5242a3090fbe553b543b124259b",
@@ -17830,7 +17955,7 @@
         "line_data_list": [
             {
                 "line": "the line will be found twice # 100 EAACEb00Kse0BAlGy7KeQ5YnaCEd09Eose0cBAlGy7KeQ5Yna9CoDsup39tiYdoQ4jH9Coup39tiYdWoQ4jHFZD",
-                "line_num": 101,
+                "line_num": 89,
                 "path": "./tests/samples/test.html",
                 "info": "FILE|HTML",
                 "value": "EAACEb00Kse0BAlGy7KeQ5YnaCEd09Eose0cBAlGy7KeQ5Yna9CoDsup39tiYdoQ4jH9Coup39tiYdWoQ4jHFZD",
@@ -17843,6 +17968,31 @@
                     "iterator": "BASE64STDPAD_CHARS",
                     "entropy": 4.936120692057913,
                     "valid": true
+                }
+            }
+        ]
+    },
+    {
+        "rule": "SQL Password",
+        "severity": "medium",
+        "confidence": "weak",
+        "ml_probability": 1.0,
+        "line_data_list": [
+            {
+                "line": "ALTER\tUSER\tdetector\tIDENTIFIED\tBY\tSqLpa5sW0rD4;",
+                "line_num": 110,
+                "path": "./tests/samples/test.html",
+                "info": "FILE|HTML",
+                "value": "SqLpa5sW0rD4",
+                "value_start": 34,
+                "value_end": 46,
+                "variable": "ALTER\tUSER\tdetector\tIDENTIFIED\tBY",
+                "variable_start": 0,
+                "variable_end": 33,
+                "entropy_validation": {
+                    "iterator": "BASE64STDPAD_CHARS",
+                    "entropy": 3.584962500721156,
+                    "valid": false
                 }
             }
         ]

--- a/tests/data/ml_threshold.json
+++ b/tests/data/ml_threshold.json
@@ -9748,6 +9748,131 @@
         ]
     },
     {
+        "rule": "UUID",
+        "severity": "info",
+        "confidence": "strong",
+        "ml_probability": null,
+        "line_data_list": [
+            {
+                "line": "   Print, crumple, throw away. line # 10 a0572bc9-7a3e-beef-cafe-9129474bcd81",
+                "line_num": 10,
+                "path": "./tests/samples/pretty.html",
+                "info": "",
+                "value": "a0572bc9-7a3e-beef-cafe-9129474bcd81",
+                "value_start": 41,
+                "value_end": 77,
+                "variable": null,
+                "variable_start": -2,
+                "variable_end": -2,
+                "entropy_validation": {
+                    "iterator": "BASE36_CHARS",
+                    "entropy": 3.4906434037593512,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
+        "rule": "Token",
+        "severity": "medium",
+        "confidence": "moderate",
+        "ml_probability": 1.0,
+        "line_data_list": [
+            {
+                "line": "        <a href=\"http://localhost:8888/v1/api/get?token=zUkITxodk63bDVUMwIymb3zKTxICz85zC00cv0Geline80\">",
+                "line_num": 79,
+                "path": "./tests/samples/pretty.html",
+                "info": "",
+                "value": "zUkITxodk63bDVUMwIymb3zKTxICz85zC00cv0Geline80",
+                "value_start": 56,
+                "value_end": 102,
+                "variable": "token",
+                "variable_start": 50,
+                "variable_end": 55,
+                "entropy_validation": {
+                    "iterator": "BASE64STDPAD_CHARS",
+                    "entropy": 4.681064401662153,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
+        "rule": "Token",
+        "severity": "medium",
+        "confidence": "moderate",
+        "ml_probability": 1.0,
+        "line_data_list": [
+            {
+                "line": "         http://localhost:8888/v1/api/get?token=zUkITxodk63bDVUMwIymb3zKTxICz85zC00cv0Geline80",
+                "line_num": 80,
+                "path": "./tests/samples/pretty.html",
+                "info": "",
+                "value": "zUkITxodk63bDVUMwIymb3zKTxICz85zC00cv0Geline80",
+                "value_start": 48,
+                "value_end": 94,
+                "variable": "token",
+                "variable_start": 42,
+                "variable_end": 47,
+                "entropy_validation": {
+                    "iterator": "BASE64STDPAD_CHARS",
+                    "entropy": 4.681064401662153,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
+        "rule": "Password",
+        "severity": "medium",
+        "confidence": "moderate",
+        "ml_probability": 1.0,
+        "line_data_list": [
+            {
+                "line": "       147# password: Jd3OnNy^564eD5_sd",
+                "line_num": 147,
+                "path": "./tests/samples/pretty.html",
+                "info": "",
+                "value": "Jd3OnNy^564eD5_sd",
+                "value_start": 22,
+                "value_end": 39,
+                "variable": "password",
+                "variable_start": 12,
+                "variable_end": 20,
+                "entropy_validation": {
+                    "iterator": "BASE64STDPAD_CHARS",
+                    "entropy": 3.371290742279712,
+                    "valid": false
+                }
+            }
+        ]
+    },
+    {
+        "rule": "UUID",
+        "severity": "info",
+        "confidence": "strong",
+        "ml_probability": null,
+        "line_data_list": [
+            {
+                "line": "        151# a0ce4d19-7a3e-beef-cafe-9129474bcd81",
+                "line_num": 151,
+                "path": "./tests/samples/pretty.html",
+                "info": "",
+                "value": "a0ce4d19-7a3e-beef-cafe-9129474bcd81",
+                "value_start": 13,
+                "value_end": 49,
+                "variable": null,
+                "variable_start": -2,
+                "variable_end": -2,
+                "entropy_validation": {
+                    "iterator": "BASE36_CHARS",
+                    "entropy": 3.3903756128027736,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
         "rule": "Password",
         "severity": "medium",
         "confidence": "moderate",

--- a/tests/data/output.json
+++ b/tests/data/output.json
@@ -7698,6 +7698,131 @@
         ]
     },
     {
+        "rule": "UUID",
+        "severity": "info",
+        "confidence": "strong",
+        "ml_probability": null,
+        "line_data_list": [
+            {
+                "line": "   Print, crumple, throw away. line # 10 a0572bc9-7a3e-beef-cafe-9129474bcd81",
+                "line_num": 10,
+                "path": "./tests/samples/pretty.html",
+                "info": "",
+                "value": "a0572bc9-7a3e-beef-cafe-9129474bcd81",
+                "value_start": 41,
+                "value_end": 77,
+                "variable": null,
+                "variable_start": -2,
+                "variable_end": -2,
+                "entropy_validation": {
+                    "iterator": "BASE36_CHARS",
+                    "entropy": 3.4906434037593512,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
+        "rule": "Token",
+        "severity": "medium",
+        "confidence": "moderate",
+        "ml_probability": 1.0,
+        "line_data_list": [
+            {
+                "line": "        <a href=\"http://localhost:8888/v1/api/get?token=zUkITxodk63bDVUMwIymb3zKTxICz85zC00cv0Geline80\">",
+                "line_num": 79,
+                "path": "./tests/samples/pretty.html",
+                "info": "",
+                "value": "zUkITxodk63bDVUMwIymb3zKTxICz85zC00cv0Geline80",
+                "value_start": 56,
+                "value_end": 102,
+                "variable": "token",
+                "variable_start": 50,
+                "variable_end": 55,
+                "entropy_validation": {
+                    "iterator": "BASE64STDPAD_CHARS",
+                    "entropy": 4.681064401662153,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
+        "rule": "Token",
+        "severity": "medium",
+        "confidence": "moderate",
+        "ml_probability": 1.0,
+        "line_data_list": [
+            {
+                "line": "         http://localhost:8888/v1/api/get?token=zUkITxodk63bDVUMwIymb3zKTxICz85zC00cv0Geline80",
+                "line_num": 80,
+                "path": "./tests/samples/pretty.html",
+                "info": "",
+                "value": "zUkITxodk63bDVUMwIymb3zKTxICz85zC00cv0Geline80",
+                "value_start": 48,
+                "value_end": 94,
+                "variable": "token",
+                "variable_start": 42,
+                "variable_end": 47,
+                "entropy_validation": {
+                    "iterator": "BASE64STDPAD_CHARS",
+                    "entropy": 4.681064401662153,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
+        "rule": "Password",
+        "severity": "medium",
+        "confidence": "moderate",
+        "ml_probability": 1.0,
+        "line_data_list": [
+            {
+                "line": "       147# password: Jd3OnNy^564eD5_sd",
+                "line_num": 147,
+                "path": "./tests/samples/pretty.html",
+                "info": "",
+                "value": "Jd3OnNy^564eD5_sd",
+                "value_start": 22,
+                "value_end": 39,
+                "variable": "password",
+                "variable_start": 12,
+                "variable_end": 20,
+                "entropy_validation": {
+                    "iterator": "BASE64STDPAD_CHARS",
+                    "entropy": 3.371290742279712,
+                    "valid": false
+                }
+            }
+        ]
+    },
+    {
+        "rule": "UUID",
+        "severity": "info",
+        "confidence": "strong",
+        "ml_probability": null,
+        "line_data_list": [
+            {
+                "line": "        151# a0ce4d19-7a3e-beef-cafe-9129474bcd81",
+                "line_num": 151,
+                "path": "./tests/samples/pretty.html",
+                "info": "",
+                "value": "a0ce4d19-7a3e-beef-cafe-9129474bcd81",
+                "value_start": 13,
+                "value_end": 49,
+                "variable": null,
+                "variable_start": -2,
+                "variable_end": -2,
+                "entropy_validation": {
+                    "iterator": "BASE36_CHARS",
+                    "entropy": 3.3903756128027736,
+                    "valid": true
+                }
+            }
+        ]
+    },
+    {
         "rule": "PyPi API Token",
         "severity": "high",
         "confidence": "strong",

--- a/tests/file_handler/test_data_content_provider.py
+++ b/tests/file_handler/test_data_content_provider.py
@@ -21,6 +21,7 @@ class DataContentProviderTest(unittest.TestCase):
     def test_represent_as_encoded_p(self) -> None:
         # surrogate parametrized test
         for param in [
+                b"QUtJQTBPTjdWMkRSNTdQTDNKWE0=\n",
                 b"\t12345\r\n\t67890  ==\n",  # with garbage
                 b"1234567890==",  #
                 b"MY/PASSWORD=",  #

--- a/tests/samples/pretty.html
+++ b/tests/samples/pretty.html
@@ -1,0 +1,165 @@
+<html>
+ <body>
+  <p>
+   Imagined API to test cred storage format.
+  </p>
+  <h3>
+   Usage
+  </h3>
+  <p>
+   Print, crumple, throw away. line # 10 a0572bc9-7a3e-beef-cafe-9129474bcd81
+  </p>
+  <h3>
+   <strong>
+    The table
+    <br/>
+   </strong>
+  </h3>
+  <table class="relative-table wrapped" style="width: 436.703px;">
+   <colgroup class="">
+    <col class="" style="width: 229.703px;"/>
+    <col class="" style="width: 206.0px;"/>
+   </colgroup>
+   <tbody class="" style="margin-left: 30.0px;">
+    <tr class="" style="margin-left: 30.0px;">
+     <td class="highlight-grey" data-highlight-colour="grey" style="text-align: left;vertical-align: top;">
+      Field name
+     </td>
+     <td class="highlight-grey" data-highlight-colour="grey" style="text-align: left;vertical-align: top;">
+      Type
+     </td>
+    </tr>
+    <tr class="" style="margin-left: 30.0px;">
+     <td colspan="1" style="text-align: left;vertical-align: top;">
+      <p>
+       user
+      </p>
+     </td>
+     <td colspan="1" style="text-align: left;vertical-align: top;">
+      <p>
+       <span style="color: rgb(0,51,102);">
+        String
+       </span>
+      </p>
+     </td>
+    </tr>
+    <tr class="" style="margin-left: 30.0px;">
+     <td colspan="1" style="text-align: left;vertical-align: top;">
+      <p>
+       token
+      </p>
+     </td>
+     <td colspan="1" style="text-align: left;vertical-align: top;">
+      <p>
+       <span style="color: rgb(0,51,102);">
+        String
+       </span>
+      </p>
+     </td>
+    </tr>
+   </tbody>
+  </table>
+  <h3>
+   <strong>
+    Sample Request:
+   </strong>
+  </h3>
+  <table class="wrapped" style="text-align: left;">
+   <tbody class="" style="text-align: left;">
+    <tr class="" style="text-align: left;">
+     <td style="text-align: left;vertical-align: baseline;">
+      <p style="text-align: left;">
+       <code class="java plain" style="text-align: left;">
+        curl --location --request GET
+        <span>
+        </span>
+       </code>
+       <code class="java string" style="text-align: left;">
+        '
+        <a href="http://localhost:8888/v1/api/get?token=zUkITxodk63bDVUMwIymb3zKTxICz85zC00cv0Geline80">
+         http://localhost:8888/v1/api/get?token=zUkITxodk63bDVUMwIymb3zKTxICz85zC00cv0Geline80
+        </a>
+        '
+       </code>
+      </p>
+     </td>
+    </tr>
+   </tbody>
+  </table>
+  <h3>
+   <strong>
+    Credentials
+    <br/>
+   </strong>
+  </h3>
+  <table class="relative-table wrapped" style="width: 418.0px;">
+   <colgroup class="">
+    <col class="" style="width: 453.0px;"/>
+    <col class="" style="width: 715.0px;"/>
+   </colgroup>
+   <thead class="">
+    <tr class="">
+     <th style="text-align: left;vertical-align: top;">
+      <p>
+       <span>
+        ip
+       </span>
+      </p>
+     </th>
+     <th style="text-align: left;vertical-align: top;">
+      <p>
+       <span>
+        id/pass
+        <br/>
+       </span>
+      </p>
+     </th>
+    </tr>
+   </thead>
+   <tbody class="">
+    <tr class="">
+     <td style="text-align: left;vertical-align: top;">
+      <pre><span style="color: rgb(106,171,115);">192.168.0.1</span></pre>
+     </td>
+     <td style="text-align: left;vertical-align: top;">
+      <pre><span style="color: rgb(106,171,115);">master/iP30dTd0</span></pre>
+     </td>
+    </tr>
+    <tr class="">
+     <td style="text-align: left;vertical-align: top;">
+      127.0.0.1
+     </td>
+     <td style="text-align: left;vertical-align: top;">
+      user/Jid8^5gvB
+     </td>
+    </tr>
+    <tr>
+     <td style="text-align: left;vertical-align: top;">
+      <p>
+       <br/>
+      </p>
+     </td>
+     <td style="text-align: left;vertical-align: top;">
+      <p>
+       user: root
+      </p>
+      <p>
+       147# password: Jd3OnNy^564eD5_sd
+      </p>
+      <blockquote>
+       <p>
+        151# a0ce4d19-7a3e-beef-cafe-9129474bcd81
+       </p>
+      </blockquote>
+     </td>
+    </tr>
+   </tbody>
+  </table>
+  <p>
+   <br/>
+  </p>
+  <p>
+   <br/>
+  </p>
+ </body>
+</html>

--- a/tests/samples/test.html
+++ b/tests/samples/test.html
@@ -115,6 +115,7 @@
     </tr>
 </table>
 
+<table><tr><td>ALTER</td><td>USER</td><td>detector</td><td>IDENTIFIED</td><td>BY</td><td>SqLpa5sW0rD4;</td></tr></table>
 
 </body>
 </html>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -586,7 +586,7 @@ class TestMain(unittest.TestCase):
     def test_html_p(self) -> None:
         # test for finding credentials in html
         content_provider: AbstractProvider = FilesProvider([SAMPLES_PATH / "test.html"])
-        cred_sweeper = CredSweeper(depth=5, ml_threshold=0)
+        cred_sweeper = CredSweeper(depth=5, ml_threshold=0, severity=Severity.LOW)
         cred_sweeper.run(content_provider=content_provider)
         found_credentials = cred_sweeper.credential_manager.get_credentials()
         expected_credential_lines = {
@@ -602,6 +602,7 @@ class TestMain(unittest.TestCase):
             "# 95 dop_v1_425522a565f532bc6532d453422e50334a42f5242a3090fbe553b543b124259b",
             "the line will be found twice # 100"
             " EAACEb00Kse0BAlGy7KeQ5YnaCEd09Eose0cBAlGy7KeQ5Yna9CoDsup39tiYdoQ4jH9Coup39tiYdWoQ4jHFZD",
+            "ALTER\tUSER\tdetector\tIDENTIFIED\tBY\tSqLpa5sW0rD4;",
         }
         found_lines_set = set(x.line_data_list[0].line for x in found_credentials)
         self.assertSetEqual(expected_credential_lines, found_lines_set)
@@ -611,10 +612,10 @@ class TestMain(unittest.TestCase):
     def test_html_n(self) -> None:
         # test_html  - no credential should be found without 'depth'
         content_provider: AbstractProvider = FilesProvider([SAMPLES_PATH / "test.html"])
-        cred_sweeper = CredSweeper()
+        cred_sweeper = CredSweeper(severity=Severity.LOW)
         cred_sweeper.run(content_provider=content_provider)
         found_credentials = cred_sweeper.credential_manager.get_credentials()
-        self.assertEqual(0, len(found_credentials))
+        self.assertListEqual([], found_credentials)
 
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
     def test_exclude_value_p(self) -> None:
@@ -655,7 +656,7 @@ class TestMain(unittest.TestCase):
 
     def test_doc_p(self) -> None:
         content_provider: AbstractProvider = FilesProvider([SAMPLES_PATH / "test.html"])
-        cred_sweeper = CredSweeper(doc=True)
+        cred_sweeper = CredSweeper(doc=True, severity=Severity.LOW)
         cred_sweeper.run(content_provider=content_provider)
         found_credentials = cred_sweeper.credential_manager.get_credentials()
         expected_credential_values = {
@@ -664,6 +665,7 @@ class TestMain(unittest.TestCase):
             "dop_v1_425522a565f532bc6532d453422e50334a42f5242a3090fbe553b543b124259b",
             "EAACEb00Kse0BAlGy7KeQ5YnaCEd09Eose0cBAlGy7KeQ5Yna9CoDsup39tiYdoQ4jH9Coup39tiYdWoQ4jHFZD",
             "MU$T6Ef09#D!",
+            "SqLpa5sW0rD4",
         }
         self.assertSetEqual(expected_credential_values, set(x.line_data_list[0].value for x in found_credentials))
 
@@ -671,10 +673,10 @@ class TestMain(unittest.TestCase):
 
     def test_doc_n(self) -> None:
         content_provider: AbstractProvider = FilesProvider([SAMPLES_PATH / "test.html"])
-        cred_sweeper = CredSweeper(doc=False)
+        cred_sweeper = CredSweeper(doc=False, severity=Severity.LOW)
         cred_sweeper.run(content_provider=content_provider)
         found_credentials = cred_sweeper.credential_manager.get_credentials()
-        self.assertEqual(0, len(found_credentials))
+        self.assertListEqual([], found_credentials)
 
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 


### PR DESCRIPTION
## Description

Please include a summary of the change and which is fixed.

- Use TAB instead LF to add separators in some html tags
- Fix Benchmark scores

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [x] UnitTest
- [x] Benchmark
