### PR TITLE
Drop Python 3.9 support - SEP.2025

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12" ]
 
     steps:
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -87,10 +87,6 @@ jobs:
 
       # # # pylint
 
-      - name: Analysing the code with pylint and minimum Python version 3.9
-        if: ${{ always() && steps.setup_credsweeper.conclusion == 'success' }}
-        run: pylint --py-version=3.9 --errors-only credsweeper
-
       - name: Analysing the code with pylint and minimum Python version 3.10
         if: ${{ always() && steps.setup_credsweeper.conclusion == 'success' }}
         run: pylint --py-version=3.10 --errors-only credsweeper
@@ -104,11 +100,6 @@ jobs:
         run: pylint --py-version=3.12 --errors-only credsweeper
 
       # # # mypy
-
-      - name: Analysing the code with mypy and minimum Python version 3.9
-        if: ${{ always() && steps.setup_credsweeper.conclusion == 'success' }}
-        run: |
-          mypy --config-file .mypy.ini --python-version=3.9 credsweeper
 
       - name: Analysing the code with mypy and minimum Python version 3.10
         if: ${{ always() && steps.setup_credsweeper.conclusion == 'success' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12" ]
 
     steps:
 
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12" ]
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Full documentation can be found here: <https://credsweeper.readthedocs.io/>
 
 ### Main Requirements
 
-- Python 3.8, 3.9, 3.10, 3.11, 3.12
+- Python 3.10, 3.11, 3.12
 
 ### Installation
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -3,7 +3,7 @@ Installation
 
 Currently `CredSweeper` requires the following prerequisites:
 
-* Python version 3.9, 3.10, 3.11, 3.12
+* Python version 3.10, 3.11, 3.12
 
 .. note::
     We recommend to use credsweeper in a separate virtual enviroment. Some heave dependencies as Tensorflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "PyYAML",
     "whatthepatch",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 license = {text = "MIT"}
 classifiers = [
@@ -38,7 +38,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.9",
     "Topic :: Security",
     "Topic :: Software Development :: Quality Assurance",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Python 3.10.16
-# pip 24.3.1
+# pip 25.0.1
 
 # build requirement
 build==1.2.2.post1
@@ -11,19 +11,17 @@ twine==6.1.0
 
 # Common requirements
 base58==2.1.1
-beautifulsoup4==4.12.3
+beautifulsoup4==4.13.3
 colorama==0.4.6
 cryptography==44.0.1
 GitPython==3.1.44
 humanfriendly==10.0
 lxml==5.3.0
-numpy==1.24.4; python_version < '3.10'
-numpy==1.26.4; python_version >= '3.10'
+numpy==2.2.2
 odfpy==1.4.1
 
 # onnxruntime - ML engine
-onnxruntime==1.19.2; python_version < '3.10'
-onnxruntime==1.20.1; python_version >= '3.10'
+onnxruntime==1.20.1 # todo check 1.20.2 soon
 
 # openpyxl - A Python library to read/write Excel 2010 xlsx/xlsm files
 openpyxl==3.1.5

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -291,9 +291,6 @@ class TestApp(TestCase):
     def test_help_p(self) -> None:
         _stdout, _stderr = self._m_credsweeper(["--help"])
         output = " ".join(_stdout.split())
-        if 10 > sys.version_info.minor and output.find("options:"):
-            # Legacy support python3.8 - 3.9 to display "optional arguments:" like in python 3.10
-            output = output.replace("options:", "optional arguments:")
         help_path = os.path.join(TESTS_PATH, "..", "docs", "source", "guide.rst")
         with open(help_path, "r") as f:
             text = ""
@@ -305,11 +302,7 @@ class TestApp(TestCase):
                     started = True
                     continue
                 if started:
-                    if 10 > sys.version_info.minor and line.strip() == "options:":
-                        # Legacy support python3.8 - 3.9 to display "optional arguments:"
-                        text = ' '.join([text, line.replace("options:", "optional arguments:")])
-                    else:
-                        text = ' '.join([text, line])
+                    text = ' '.join([text, line])
             expected = " ".join(text.split())
             self.assertEqual(expected, output)
 


### PR DESCRIPTION
## Description

Please include a summary of the change and which is fixed.

- Drop support python 3.9 in September 2025 (https://peps.python.org/pep-0596/)
- Update packages with the limitations

## How has this been tested?

Please describe the tests that you ran to verify your changes.

- [ ] UnitTest
- [ ] Benchmark
